### PR TITLE
bumping version to 1.2.2

### DIFF
--- a/.github/workflows/opensearch-observability-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-observability-test-and-build-workflow.yml
@@ -3,7 +3,7 @@ name: Test and Build OpenSearch Observability Backend Plugin
 on: [pull_request, push]
 
 env:
-  OPENSEARCH_VERSION: '1.2.1-SNAPSHOT'
+  OPENSEARCH_VERSION: '1.2.2-SNAPSHOT'
   OPENSEARCH_BRANCH: '1.2'
   COMMON_UTILS_BRANCH: 'main'
 

--- a/opensearch-observability/build.gradle
+++ b/opensearch-observability/build.gradle
@@ -9,7 +9,7 @@ import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.2.1-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "1.2.2-SNAPSHOT")
         // 1.0.0 -> 1.0.0.0, and 1.0.0-SNAPSHOT -> 1.0.0.0-SNAPSHOT
         opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
@@ -262,7 +262,7 @@ String bwcFilePath = "src/test/kotlin/org/opensearch/observability/resources/bwc
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-            versions = ["1.1.0","1.2.1-SNAPSHOT"]
+            versions = ["1.1.0","1.2.2-SNAPSHOT"]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>(){
                 @Override

--- a/release-notes/opensearch-trace-analytics.release-notes-1.2.2.0.md
+++ b/release-notes/opensearch-trace-analytics.release-notes-1.2.2.0.md
@@ -3,4 +3,4 @@
 Compatible with OpenSearch Version 1.2.2 and OpenSearch Dashboards Version 1.2.0
 
 ### Maintenance
-* Bump observability version for OpenSearch 1.2.2 release 
+* Bump observability version for OpenSearch 1.2.2 release [#346](https://github.com/opensearch-project/observability/pull/346)

--- a/release-notes/opensearch-trace-analytics.release-notes-1.2.2.0.md
+++ b/release-notes/opensearch-trace-analytics.release-notes-1.2.2.0.md
@@ -1,0 +1,6 @@
+## Version 1.2.2.0 Release Notes
+
+Compatible with OpenSearch Version 1.2.2 and OpenSearch Dashboards Version 1.2.0
+
+### Maintenance
+* Bump observability version for OpenSearch 1.2.2 release 


### PR DESCRIPTION
Signed-off-by: Shenoy Pratik <sgguruda@amazon.com>

### Description
Bump up version to 1.2.2

### Issues Resolved
Preparing for potential release to address https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
