### PR TITLE
bump main to 1.3

### DIFF
--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -6,7 +6,7 @@ on: [pull_request, push]
 env:
   PLUGIN_NAME: dashboards-observability
   OPENSEARCH_VERSION: '1.x'
-  OPENSEARCH_PLUGIN_VERSION: 1.2.0.0
+  OPENSEARCH_PLUGIN_VERSION: 1.3.0.0
 
 jobs:
 

--- a/.github/workflows/opensearch-observability-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-observability-test-and-build-workflow.yml
@@ -3,8 +3,8 @@ name: Test and Build OpenSearch Observability Backend Plugin
 on: [pull_request, push]
 
 env:
-  OPENSEARCH_VERSION: '1.2.3-SNAPSHOT'
-  OPENSEARCH_BRANCH: '1.2'
+  OPENSEARCH_VERSION: '1.3.0-SNAPSHOT'
+  OPENSEARCH_BRANCH: '1.3'
   COMMON_UTILS_BRANCH: 'main'
 
 jobs:

--- a/dashboards-observability/opensearch_dashboards.json
+++ b/dashboards-observability/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "observabilityDashboards",
-  "version": "1.2.0.0",
-  "opensearchDashboardsVersion": "1.2.0",
+  "version": "1.3.0.0",
+  "opensearchDashboardsVersion": "1.3.0",
   "server": true,
   "ui": true,
   "requiredPlugins": [

--- a/dashboards-observability/package.json
+++ b/dashboards-observability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "observability-dashboards",
-  "version": "1.2.0.0",
+  "version": "1.3.0.0",
   "main": "index.ts",
   "license": "Apache-2.0",
   "scripts": {

--- a/opensearch-observability/build.gradle
+++ b/opensearch-observability/build.gradle
@@ -9,7 +9,7 @@ import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.2.3-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "1.3.0-SNAPSHOT")
         // 1.0.0 -> 1.0.0.0, and 1.0.0-SNAPSHOT -> 1.0.0.0-SNAPSHOT
         opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)


### PR DESCRIPTION
Signed-off-by: Shenoy Pratik <sgguruda@amazon.com>

### Description
Updated main to latest build

### Issues Resolved
1. Build workflows with 1.3.0
2. Updated gradle build and dashboards json files to match latest build

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
