### PR TITLE
Filter out panels from App Analytics

### DIFF
--- a/dashboards-observability/common/types/custom_panels.ts
+++ b/dashboards-observability/common/types/custom_panels.ts
@@ -8,6 +8,7 @@ export type CustomPanelListType = {
   id: string;
   dateCreated: number;
   dateModified: number;
+  applicationId?: string;
 };
 
 export type VisualizationType = {

--- a/dashboards-observability/public/components/custom_panels/home.tsx
+++ b/dashboards-observability/public/components/custom_panels/home.tsx
@@ -19,7 +19,7 @@ import {
   OBSERVABILITY_BASE,
   SAVED_OBJECTS,
 } from '../../../common/constants/shared';
-import { CustomPanelListType } from '../../../common/types/custom_panels';
+import { CustomPanelListType, PanelType } from '../../../common/types/custom_panels';
 import { ObservabilitySideBar } from '../common/side_nav';
 import { CustomPanelTable } from './custom_panel_table';
 import { CustomPanelView } from './custom_panel_view';
@@ -62,7 +62,9 @@ export const Home = ({ http, chrome, parentBreadcrumb, pplService, renderProps }
     http
       .get(`${CUSTOM_PANELS_API_PREFIX}/panels`)
       .then((res) => {
-        setcustomPanelData(res.panels);
+        // Filter out panels that do not have applicationId field
+        const nonAppPanels = res.panels.filter((p: PanelType) => !p.applicationId);
+        setcustomPanelData(nonAppPanels);
       })
       .catch((err) => {
         console.error('Issue in fetching the operational panels', err.body.message);

--- a/dashboards-observability/public/components/custom_panels/home.tsx
+++ b/dashboards-observability/public/components/custom_panels/home.tsx
@@ -19,7 +19,7 @@ import {
   OBSERVABILITY_BASE,
   SAVED_OBJECTS,
 } from '../../../common/constants/shared';
-import { CustomPanelListType, PanelType } from '../../../common/types/custom_panels';
+import { CustomPanelListType } from '../../../common/types/custom_panels';
 import { ObservabilitySideBar } from '../common/side_nav';
 import { CustomPanelTable } from './custom_panel_table';
 import { CustomPanelView } from './custom_panel_view';

--- a/dashboards-observability/public/components/custom_panels/home.tsx
+++ b/dashboards-observability/public/components/custom_panels/home.tsx
@@ -62,9 +62,7 @@ export const Home = ({ http, chrome, parentBreadcrumb, pplService, renderProps }
     http
       .get(`${CUSTOM_PANELS_API_PREFIX}/panels`)
       .then((res) => {
-        // Filter out panels that do not have applicationId field
-        const nonAppPanels = res.panels.filter((p: PanelType) => !p.applicationId);
-        setcustomPanelData(nonAppPanels);
+        setcustomPanelData(res.panels);
       })
       .catch((err) => {
         console.error('Issue in fetching the operational panels', err.body.message);

--- a/dashboards-observability/server/adaptors/custom_panels/custom_panel_adaptor.ts
+++ b/dashboards-observability/server/adaptors/custom_panels/custom_panel_adaptor.ts
@@ -71,20 +71,14 @@ export class CustomPanelsAdaptor {
         objectType: 'operationalPanel',
         maxItems: 10000,
       });
-      const panelList: any[] = [];
-      for (const panel of response.observabilityObjectList) {
-        if (panel.operationalPanel.applicationId) {
-          break;
-        }
-        const panelObject: CustomPanelListType = {
-          name: panel.operationalPanel.name,
-          id: panel.objectId,
-          dateCreated: panel.createdTimeMs,
-          dateModified: panel.lastUpdatedTimeMs
-        }
-        panelList.push(panelObject);
-      }
-      return panelList;
+      return response.observabilityObjectList
+        .filter((panel: any) => !panel.operationalPanel.applicationId)
+        .map((panel: any) => ({
+        name: panel.operationalPanel.name,
+        id: panel.objectId,
+        dateCreated: panel.createdTimeMs,
+        dateModified: panel.lastUpdatedTimeMs,
+      }));
     } catch (error) {
       throw new Error('View Panel List Error:' + error);
     }

--- a/dashboards-observability/server/adaptors/custom_panels/custom_panel_adaptor.ts
+++ b/dashboards-observability/server/adaptors/custom_panels/custom_panel_adaptor.ts
@@ -73,14 +73,14 @@ export class CustomPanelsAdaptor {
       });
       const panelList: any[] = [];
       for (const panel of response.observabilityObjectList) {
+        if (panel.operationalPanel.applicationId) {
+          break;
+        }
         const panelObject: CustomPanelListType = {
           name: panel.operationalPanel.name,
           id: panel.objectId,
           dateCreated: panel.createdTimeMs,
           dateModified: panel.lastUpdatedTimeMs
-        }
-        if (panel.operationalPanel.applicationId) {
-          panelObject.applicationId = panel.operationalPanel.applicationId;
         }
         panelList.push(panelObject);
       }

--- a/dashboards-observability/server/adaptors/custom_panels/custom_panel_adaptor.ts
+++ b/dashboards-observability/server/adaptors/custom_panels/custom_panel_adaptor.ts
@@ -71,18 +71,18 @@ export class CustomPanelsAdaptor {
         objectType: 'operationalPanel',
         maxItems: 10000,
       });
-      var panelList: any[] = [];
+      const panelList: any[] = [];
       for (const panel of response.observabilityObjectList) {
-        var object: CustomPanelListType = {
+        const panelObject: CustomPanelListType = {
           name: panel.operationalPanel.name,
           id: panel.objectId,
           dateCreated: panel.createdTimeMs,
           dateModified: panel.lastUpdatedTimeMs
         }
         if (panel.operationalPanel.applicationId) {
-          object.applicationId = panel.operationalPanel.applicationId;
+          panelObject.applicationId = panel.operationalPanel.applicationId;
         }
-        panelList.push(object);
+        panelList.push(panelObject);
       }
       return panelList;
     } catch (error) {

--- a/dashboards-observability/server/adaptors/custom_panels/custom_panel_adaptor.ts
+++ b/dashboards-observability/server/adaptors/custom_panels/custom_panel_adaptor.ts
@@ -4,7 +4,7 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
-import { PanelType, VisualizationType } from '../../../common/types/custom_panels';
+import { CustomPanelListType, PanelType, VisualizationType } from '../../../common/types/custom_panels';
 import { ILegacyScopedClusterClient } from '../../../../../src/core/server';
 import { createDemoPanel } from '../../common/helpers/custom_panels/sample_panels';
 
@@ -71,12 +71,20 @@ export class CustomPanelsAdaptor {
         objectType: 'operationalPanel',
         maxItems: 10000,
       });
-      return response.observabilityObjectList.map((panel: any) => ({
-        name: panel.operationalPanel.name,
-        id: panel.objectId,
-        dateCreated: panel.createdTimeMs,
-        dateModified: panel.lastUpdatedTimeMs,
-      }));
+      var panelList: any[] = [];
+      for (const panel of response.observabilityObjectList) {
+        var object: CustomPanelListType = {
+          name: panel.operationalPanel.name,
+          id: panel.objectId,
+          dateCreated: panel.createdTimeMs,
+          dateModified: panel.lastUpdatedTimeMs
+        }
+        if (panel.operationalPanel.applicationId) {
+          object.applicationId = panel.operationalPanel.applicationId;
+        }
+        panelList.push(object);
+      }
+      return panelList;
     } catch (error) {
       throw new Error('View Panel List Error:' + error);
     }


### PR DESCRIPTION
Signed-off-by: Eugene Lee <eugenesk@amazon.com>

### Description
Add applicationId field when fetching panels.
Filter out panels that have applicationId field on Operational Panels.

### Issues Resolved
#416 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
