### PR TITLE
Create visualizations for application analytics

### DIFF
--- a/dashboards-observability/common/types/custom_panels.ts
+++ b/dashboards-observability/common/types/custom_panels.ts
@@ -34,6 +34,7 @@ export type SavedVisualizationType = {
   query: string;
   type: string;
   timeField: string;
+  application_id?: string;
 };
 
 export type pplResponse = {

--- a/dashboards-observability/common/types/explorer.ts
+++ b/dashboards-observability/common/types/explorer.ts
@@ -102,4 +102,5 @@ export interface IExplorerProps {
   tabCreatedTypes?: any;
   searchBarConfigs?: any;
   appId?: string;
+  addVisualizationToPanel: (visualizationId: string, visualizationName: string) => Promise<void>;
 }

--- a/dashboards-observability/common/types/explorer.ts
+++ b/dashboards-observability/common/types/explorer.ts
@@ -100,4 +100,6 @@ export interface IExplorerProps {
   ) => void;
   http: CoreStart['http'];
   tabCreatedTypes?: any;
+  searchBarConfigs?: any;
+  appId?: string;
 }

--- a/dashboards-observability/public/components/application_analytics/components/application.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/application.tsx
@@ -21,7 +21,6 @@ import TimestampUtils from 'public/services/timestamp/timestamp';
 import React, { ReactChild, useEffect, useState } from 'react';
 import { uniqueId } from 'lodash';
 import { useHistory } from 'react-router-dom';
-import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
 import { Explorer } from '../../explorer/explorer';
 import { Dashboard } from '../../trace_analytics/components/dashboard';
 import { Services } from '../../trace_analytics/components/services';
@@ -49,6 +48,7 @@ import { NotificationsStart } from '../../../../../../src/core/public';
 import { AppAnalyticsComponentDeps } from '../home';
 import { CustomPanelView } from '../../../../public/components/custom_panels/custom_panel_view';
 import { ApplicationType } from '../../../../common/types/app_analytics';
+import { CUSTOM_PANELS_API_PREFIX } from '../../../../common/constants/custom_panels';
 
 const TAB_OVERVIEW_ID = uniqueId(TAB_OVERVIEW_ID_TXT_PFX);
 const TAB_SERVICE_ID = uniqueId(TAB_SERVICE_ID_TXT_PFX);
@@ -144,6 +144,21 @@ export function Application(props: AppDetailProps) {
       });
   };
 
+  // Add visualization to application's panel
+  const addVisualizationToPanel = async (visualizationId: string, visualizationName: string) => {
+    return http
+      .post(`${CUSTOM_PANELS_API_PREFIX}/visualizations`, {
+        body: JSON.stringify({
+          panelId: application.panelId,
+          savedVisualizationId: visualizationId,
+        }),
+      })
+      .catch((err) => {
+        setToasts(`Error in adding ${visualizationName} visualization to the panel`, 'danger');
+        console.error(err);
+      });
+  }
+
   useEffect(() => {
     fetchAppById(appId);
   }, [appId]);
@@ -196,6 +211,7 @@ export function Application(props: AppDetailProps) {
         http={http}
         searchBarConfigs={searchBarConfigs}
         appId={appId}
+        addVisualizationToPanel={addVisualizationToPanel}
       />
     );
   };

--- a/dashboards-observability/public/components/application_analytics/components/application.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/application.tsx
@@ -211,8 +211,8 @@ export function Application(props: AppDetailProps) {
         notifications={notifications}
         savedObjectId={''}
         http={http}
-        showSaveButton={true}
         searchBarConfigs={searchBarConfigs}
+        appId={appId}
       />
     );
   };

--- a/dashboards-observability/public/components/application_analytics/home.tsx
+++ b/dashboards-observability/public/components/application_analytics/home.tsx
@@ -311,6 +311,7 @@ export const Home = (props: HomeProps) => {
               savedObjects={savedObjects}
               timestampUtils={timestampUtils}
               notifications={notifications}
+              setToasts={setToast}
               {...commonProps}
             />
           }

--- a/dashboards-observability/public/components/explorer/explorer.tsx
+++ b/dashboards-observability/public/components/explorer/explorer.tsx
@@ -74,6 +74,7 @@ export const Explorer = ({
   notifications,
   savedObjectId,
   searchBarConfigs,
+  appId = '',
 }: IExplorerProps) => {
   const dispatch = useDispatch();
   const requestParams = { tabId };
@@ -493,6 +494,7 @@ export const Explorer = ({
                   handleOverrideTimestamp={handleOverrideTimestamp}
                   handleAddField={(field: IField) => handleAddField(field)}
                   handleRemoveField={(field: IField) => handleRemoveField(field)}
+                  isOverridingTimestamp={isOverridingTimestamp}
                   isFieldToggleButtonDisabled={
                     isEmpty(explorerData.jsonData) ||
                     !isEmpty(queryRef.current![RAW_QUERY].match(PPL_STATS_REGEX))
@@ -689,6 +691,8 @@ export const Explorer = ({
       dateRange: currQuery![SELECTED_DATE_RANGE],
       name: selectedPanelNameRef.current,
       timestamp: currQuery![SELECTED_TIMESTAMP],
+      objectId: '',
+      type: ''
     };
     if (isEqual(selectedContentTabId, TAB_EVENT_ID)) {
       const isTabMatchingSavedType = isEqual(currQuery![SAVED_OBJECT_TYPE], SAVED_QUERY);
@@ -798,6 +802,7 @@ export const Explorer = ({
             type: curVisId,
             name: selectedPanelNameRef.current,
             timestamp: currQuery![SELECTED_TIMESTAMP],
+            applicationId: appId
           })
           .then((res: any) => {
             batch(() => {

--- a/dashboards-observability/public/components/explorer/explorer.tsx
+++ b/dashboards-observability/public/components/explorer/explorer.tsx
@@ -822,7 +822,9 @@ export const Explorer = ({
                 })
               );
             });
-            history.replace(`/event_analytics/explorer/${res.objectId}`);
+            if (tabId !== "application-analytics-tab") {
+              history.replace(`/event_analytics/explorer/${res.objectId}`);
+            }
             setToast(
               `New visualization '${selectedPanelNameRef.current}' has been successfully saved.`,
               'success'

--- a/dashboards-observability/public/components/explorer/explorer.tsx
+++ b/dashboards-observability/public/components/explorer/explorer.tsx
@@ -75,6 +75,7 @@ export const Explorer = ({
   savedObjectId,
   searchBarConfigs,
   appId = '',
+  addVisualizationToPanel,
 }: IExplorerProps) => {
   const dispatch = useDispatch();
   const requestParams = { tabId };
@@ -822,7 +823,9 @@ export const Explorer = ({
                 })
               );
             });
-            if (tabId !== "application-analytics-tab") {
+            if (tabId === "application-analytics-tab") {
+              addVisualizationToPanel(res.objectId, selectedPanelNameRef.current);
+            } else {
               history.replace(`/event_analytics/explorer/${res.objectId}`);
             }
             setToast(

--- a/dashboards-observability/public/components/explorer/home.tsx
+++ b/dashboards-observability/public/components/explorer/home.tsx
@@ -109,7 +109,8 @@ export const Home = (props: IHomeProps) => {
       sortOrder: 'desc',
       fromIndex: 0,
     });
-    setSavedHistories(res['observabilityObjectList']);
+    const nonAppVisualizations = res['observabilityObjectList'].filter((object: any) => !object.savedVisualization.applicationId);
+    setSavedHistories(nonAppVisualizations);
   };
 
   const deleteHistoryList = async () => {

--- a/dashboards-observability/public/components/explorer/home.tsx
+++ b/dashboards-observability/public/components/explorer/home.tsx
@@ -109,7 +109,7 @@ export const Home = (props: IHomeProps) => {
       sortOrder: 'desc',
       fromIndex: 0,
     });
-    const nonAppVisualizations = res['observabilityObjectList'].filter((object: any) => !object.savedVisualization.applicationId);
+    const nonAppVisualizations = res['observabilityObjectList'].filter((object: any) => object.savedVisualization && !object.savedVisualization.application_id);
     setSavedHistories(nonAppVisualizations);
   };
 

--- a/dashboards-observability/public/components/explorer/log_explorer.tsx
+++ b/dashboards-observability/public/components/explorer/log_explorer.tsx
@@ -209,7 +209,6 @@ export const LogExplorer = ({
             savedObjectId={savedObjectId}
             tabCreatedTypes={tabCreatedTypes}
             http={http}
-            showSaveButton={true}
             searchBarConfigs={searchBarConfigs}
           />
         </>

--- a/dashboards-observability/public/services/saved_objects/event_analytics/saved_objects.ts
+++ b/dashboards-observability/public/services/saved_objects/event_analytics/saved_objects.ts
@@ -58,10 +58,11 @@ export default class SavedObjects {
     timestamp,
     name = '',
     chartType = '',
-    description = ''
+    description = '',
+    applicationId = ''
   }: any) {
 
-    const objRequest = {
+    const objRequest: any = {
       object: {
         query,
         selected_date_range: {
@@ -84,6 +85,10 @@ export default class SavedObjects {
 
     if (!isEmpty(chartType)) {
       objRequest['object']['type'] = chartType;
+    }
+
+    if (!isEmpty(applicationId)) {
+      objRequest['object']['application_id'] = applicationId;
     }
 
     return objRequest;
@@ -231,7 +236,8 @@ export default class SavedObjects {
       dateRange: params.dateRange,
       chartType: params.type,
       name: params.name,
-      timestamp: params.timestamp
+      timestamp: params.timestamp,
+      applicationId: params.applicationId
     });
 
     return await this.http.post(

--- a/dashboards-observability/server/adaptors/custom_panels/custom_panel_adaptor.ts
+++ b/dashboards-observability/server/adaptors/custom_panels/custom_panel_adaptor.ts
@@ -205,13 +205,17 @@ export class CustomPanelsAdaptor {
       const response = await client.callAsCurrentUser('observability.getObject', {
         objectType: 'savedVisualization',
       });
-      return response.observabilityObjectList.map((visualization: any) => ({
-        id: visualization.objectId,
-        name: visualization.savedVisualization.name,
-        query: visualization.savedVisualization.query,
-        type: visualization.savedVisualization.type,
-        timeField: visualization.savedVisualization.selected_timestamp.name,
-      }));
+      return response.observabilityObjectList
+        .filter((visualization: any) => {
+          return !!!visualization.savedVisualization.application_id;
+        })
+        .map((visualization: any) => ({
+          id: visualization.objectId,
+          name: visualization.savedVisualization.name,
+          query: visualization.savedVisualization.query,
+          type: visualization.savedVisualization.type,
+          timeField: visualization.savedVisualization.selected_timestamp.name,
+        }));
     } catch (error) {
       throw new Error('View Saved Visualizations Error:' + error);
     }
@@ -240,7 +244,6 @@ export class CustomPanelsAdaptor {
   };
 
   //Get All Visualizations from a Panel
-  //Add Visualization
   getVisualizations = async (client: ILegacyScopedClusterClient, panelId: string) => {
     try {
       const response = await client.callAsCurrentUser('observability.getObjectById', {

--- a/dashboards-observability/server/routes/event_analytics/event_analytics_router.ts
+++ b/dashboards-observability/server/routes/event_analytics/event_analytics_router.ts
@@ -116,6 +116,7 @@ export const registerEventAnalyticsRouter = ({
           type: schema.string(),
           name: schema.string(),
           description: schema.string(),
+          application_id: schema.maybe(schema.string()),
         })
     })}
   },
@@ -203,6 +204,7 @@ export const registerEventAnalyticsRouter = ({
           type: schema.string(),
           name: schema.string(),
           description: schema.string(),
+          application_id: schema.maybe(schema.string()),
         })
     })}
   },


### PR DESCRIPTION
### Description
- Adds `application_id` to saved visualization creation request
- A visualization created on the Log Events tab of Application Analytics will automatically be saved to the corresponding application's panel
- Visualizations created within Application Analytics will not show up in Operational Panels or Event Analytics.

### Issues Resolved
Resolves #386 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
