### PR TITLE
Sync time range within application

### DIFF
--- a/dashboards-observability/common/types/explorer.ts
+++ b/dashboards-observability/common/types/explorer.ts
@@ -105,4 +105,6 @@ export interface IExplorerProps {
   addVisualizationToPanel?: any;
   startTime?: string;
   endTime?: string;
+  setStartTime?: any;
+  setEndTime?: any;
 }

--- a/dashboards-observability/common/types/explorer.ts
+++ b/dashboards-observability/common/types/explorer.ts
@@ -102,5 +102,7 @@ export interface IExplorerProps {
   tabCreatedTypes?: any;
   searchBarConfigs?: any;
   appId?: string;
-  addVisualizationToPanel: (visualizationId: string, visualizationName: string) => Promise<void>;
+  addVisualizationToPanel?: any;
+  startTime?: string;
+  endTime?: string;
 }

--- a/dashboards-observability/public/components/application_analytics/components/app_table.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/app_table.tsx
@@ -55,6 +55,7 @@ export function AppTable(props: AppTableProps) {
     fetchApplications,
     renameApplication,
     deleteApplication,
+    setFilters,
   } = props;
 
   useEffect(() => {
@@ -65,6 +66,7 @@ export function AppTable(props: AppTableProps) {
         href: '#/application_analytics',
       },
     ]);
+    setFilters([]);
     fetchApplications();
   }, []);
 

--- a/dashboards-observability/public/components/application_analytics/components/app_table.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/app_table.tsx
@@ -56,6 +56,8 @@ export function AppTable(props: AppTableProps) {
     renameApplication,
     deleteApplication,
     setFilters,
+    setStartTime,
+    setEndTime,
   } = props;
 
   useEffect(() => {
@@ -66,9 +68,15 @@ export function AppTable(props: AppTableProps) {
         href: '#/application_analytics',
       },
     ]);
-    setFilters([]);
+    clear();
     fetchApplications();
   }, []);
+
+  const clear = () => {
+    setFilters([]);
+    setStartTime('now-24M');
+    setEndTime('now');
+  };
 
   const closeModal = () => {
     setIsModalVisible(false);

--- a/dashboards-observability/public/components/application_analytics/components/application.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/application.tsx
@@ -102,6 +102,8 @@ export function Application(props: AppDetailProps) {
     appId,
     chrome,
     parentBreadcrumb,
+    startTime,
+    endTime,
     setFilters,
     setToasts,
   } = props;
@@ -264,6 +266,8 @@ export function Application(props: AppDetailProps) {
         searchBarConfigs={searchBarConfigs}
         appId={appId}
         addVisualizationToPanel={addVisualizationToPanel}
+        startTime={startTime}
+        endTime={endTime}
       />
     );
   };

--- a/dashboards-observability/public/components/application_analytics/components/application.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/application.tsx
@@ -270,6 +270,8 @@ export function Application(props: AppDetailProps) {
         addVisualizationToPanel={addVisualizationToPanel}
         startTime={startTime}
         endTime={endTime}
+        setStartTime={setStartTime}
+        setEndTime={setEndTime}
       />
     );
   };

--- a/dashboards-observability/public/components/application_analytics/components/application.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/application.tsx
@@ -104,6 +104,8 @@ export function Application(props: AppDetailProps) {
     parentBreadcrumb,
     startTime,
     endTime,
+    setStartTime,
+    setEndTime,
     setFilters,
     setToasts,
   } = props;
@@ -288,6 +290,10 @@ export function Application(props: AppDetailProps) {
         page="app"
         appName={application.name}
         appId={appId}
+        startTime={startTime}
+        endTime={endTime}
+        setStartTime={setStartTime}
+        setEndTime={setEndTime}
       />
     );
   };

--- a/dashboards-observability/public/components/application_analytics/home.tsx
+++ b/dashboards-observability/public/components/application_analytics/home.tsx
@@ -77,7 +77,7 @@ export const Home = (props: HomeProps) => {
   );
   const [query, setQuery] = useState<string>(sessionStorage.getItem('AppAnalyticsQuery') || '');
   const [startTime, setStartTime] = useState<string>(
-    sessionStorage.getItem('AppAnalyticsStartTime') || 'now-24h'
+    sessionStorage.getItem('AppAnalyticsStartTime') || 'now-24M'
   );
   const [endTime, setEndTime] = useState<string>(
     sessionStorage.getItem('AppAnalyticsEndTime') || 'now'

--- a/dashboards-observability/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view.test.tsx.snap
+++ b/dashboards-observability/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view.test.tsx.snap
@@ -72,6 +72,7 @@ exports[`Panels View Component renders panel view container with visualizations 
   }
   cloneCustomPanel={[MockFunction]}
   deleteCustomPanel={[MockFunction]}
+  endTime="now"
   http={[MockFunction]}
   panelId="L8Sx53wBDp0rvEg3yoLb"
   parentBreadcrumb={
@@ -93,7 +94,10 @@ exports[`Panels View Component renders panel view container with visualizations 
     }
   }
   renameCustomPanel={[MockFunction]}
+  setEndTime={[MockFunction]}
+  setStartTime={[MockFunction]}
   setToast={[MockFunction]}
+  startTime="now-30m"
 >
   <div>
     <EuiPage>
@@ -1536,24 +1540,8 @@ exports[`Panels View Component renders panel view container with visualizations 
           Array [],
           Array [],
           Array [],
-          Array [],
-          Array [],
         ],
         "results": Array [
-          Object {
-            "type": "return",
-            "value": Observable {
-              "_isScalar": false,
-              "_subscribe": [Function],
-            },
-          },
-          Object {
-            "type": "return",
-            "value": Observable {
-              "_isScalar": false,
-              "_subscribe": [Function],
-            },
-          },
           Object {
             "type": "return",
             "value": Observable {
@@ -1683,6 +1671,7 @@ exports[`Panels View Component renders panel view container with visualizations 
   }
   cloneCustomPanel={[MockFunction]}
   deleteCustomPanel={[MockFunction]}
+  endTime="now"
   http={[MockFunction]}
   panelId="L8Sx53wBDp0rvEg3yoLb"
   parentBreadcrumb={
@@ -1704,7 +1693,38 @@ exports[`Panels View Component renders panel view container with visualizations 
     }
   }
   renameCustomPanel={[MockFunction]}
+  setEndTime={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          "now",
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
+  setStartTime={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          "now-30m",
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
   setToast={[MockFunction]}
+  startTime="now-30m"
 >
   <div>
     <EuiPage>
@@ -2942,24 +2962,8 @@ exports[`Panels View Component renders panel view container with visualizations 
                           Array [],
                           Array [],
                           Array [],
-                          Array [],
-                          Array [],
                         ],
                         "results": Array [
-                          Object {
-                            "type": "return",
-                            "value": Observable {
-                              "_isScalar": false,
-                              "_subscribe": [Function],
-                            },
-                          },
-                          Object {
-                            "type": "return",
-                            "value": Observable {
-                              "_isScalar": false,
-                              "_subscribe": [Function],
-                            },
-                          },
                           Object {
                             "type": "return",
                             "value": Observable {
@@ -3294,6 +3298,7 @@ exports[`Panels View Component renders panel view container without visualizatio
   }
   cloneCustomPanel={[MockFunction]}
   deleteCustomPanel={[MockFunction]}
+  endTime="now"
   http={[MockFunction]}
   panelId="L8Sx53wBDp0rvEg3yoLb"
   parentBreadcrumb={
@@ -3315,7 +3320,10 @@ exports[`Panels View Component renders panel view container without visualizatio
     }
   }
   renameCustomPanel={[MockFunction]}
+  setEndTime={[MockFunction]}
+  setStartTime={[MockFunction]}
   setToast={[MockFunction]}
+  startTime="now-30m"
 >
   <div>
     <EuiPage>

--- a/dashboards-observability/public/components/custom_panels/__tests__/custom_panel_view.test.tsx
+++ b/dashboards-observability/public/components/custom_panels/__tests__/custom_panel_view.test.tsx
@@ -32,6 +32,10 @@ describe('Panels View Component', () => {
     const pplService = new PPLService(httpClientMock);
     const core = coreStartMock;
     const parentBreadcrumb = panelBreadCrumbs;
+    const start = 'now-30m';
+    const end = 'now';
+    const setStart = jest.fn();
+    const setEnd = jest.fn();
     const renameCustomPanel = jest.fn();
     const cloneCustomPanel = jest.fn();
     const deleteCustomPanel = jest.fn();
@@ -48,6 +52,10 @@ describe('Panels View Component', () => {
         cloneCustomPanel={cloneCustomPanel}
         deleteCustomPanel={deleteCustomPanel}
         setToast={setToast}
+        startTime={start}
+        endTime={end}
+        setStartTime={setStart}
+        setEndTime={setEnd}
       />
     );
     wrapper.update();
@@ -76,6 +84,10 @@ describe('Panels View Component', () => {
     const pplService = new PPLService(httpClientMock);
     const core = coreStartMock;
     const parentBreadcrumb = panelBreadCrumbs;
+    const start = 'now-30m';
+    const end = 'now';
+    const setStart = jest.fn();
+    const setEnd = jest.fn();
     const renameCustomPanel = jest.fn();
     const cloneCustomPanel = jest.fn();
     const deleteCustomPanel = jest.fn();
@@ -92,6 +104,10 @@ describe('Panels View Component', () => {
         cloneCustomPanel={cloneCustomPanel}
         deleteCustomPanel={deleteCustomPanel}
         setToast={setToast}
+        startTime={start}
+        endTime={end}
+        setStartTime={setStart}
+        setEndTime={setEnd}
       />
     );
     wrapper.update();

--- a/dashboards-observability/public/components/custom_panels/custom_panel_table.tsx
+++ b/dashboards-observability/public/components/custom_panels/custom_panel_table.tsx
@@ -29,6 +29,8 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import React, { ReactElement, useEffect, useState } from 'react';
+import moment from 'moment';
+import _ from 'lodash';
 import { ChromeBreadcrumb } from '../../../../../src/core/public';
 import {
   CREATE_PANEL_MESSAGE,
@@ -36,8 +38,6 @@ import {
 } from '../../../common/constants/custom_panels';
 import { UI_DATE_FORMAT } from '../../../common/constants/shared';
 import { getCustomModal, DeletePanelModal } from './helpers/modal_containers';
-import moment from 'moment';
-import _ from 'lodash';
 import { CustomPanelListType } from '../../../common/types/custom_panels';
 import { getSampleDataModal } from '../common/helpers/add_sample_modal';
 import { pageStyles } from '../../../common/constants/shared';
@@ -57,10 +57,10 @@ import { pageStyles } from '../../../common/constants/shared';
  * deleteCustomPanelList: delete function for the panels
  */
 
-type Props = {
+interface Props {
   loading: boolean;
   fetchCustomPanels: () => void;
-  customPanels: Array<CustomPanelListType>;
+  customPanels: CustomPanelListType[];
   createCustomPanel: (newCustomPanelName: string) => void;
   setBreadcrumbs: (newBreadcrumbs: ChromeBreadcrumb[]) => void;
   parentBreadcrumb: EuiBreadcrumb[];
@@ -68,7 +68,7 @@ type Props = {
   cloneCustomPanel: (newCustomPanelName: string, customPanelId: string) => void;
   deleteCustomPanelList: (customPanelIdList: string[], toastMessage: string) => any;
   addSamplePanels: () => void;
-};
+}
 
 export const CustomPanelTable = ({
   loading,
@@ -83,7 +83,7 @@ export const CustomPanelTable = ({
   addSamplePanels,
 }: Props) => {
   const [isModalVisible, setIsModalVisible] = useState(false); // Modal Toggle
-  const [modalLayout, setModalLayout] = useState(<EuiOverlayMask></EuiOverlayMask>); // Modal Layout
+  const [modalLayout, setModalLayout] = useState(<EuiOverlayMask />); // Modal Layout
   const [isActionsPopoverOpen, setIsActionsPopoverOpen] = useState(false);
   const [selectedCustomPanels, setselectedCustomPanels] = useState<CustomPanelListType[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
@@ -316,8 +316,8 @@ export const CustomPanelTable = ({
                     </EuiPopover>
                   </EuiFlexItem>
                   <EuiFlexItem>
-                    <EuiButton 
-                      fill 
+                    <EuiButton
+                      fill
                       onClick={() => createPanel()}
                       data-test-subj="customPanels__createNewPanels"
                     >

--- a/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
+++ b/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
@@ -6,7 +6,6 @@
 import {
   EuiBreadcrumb,
   EuiButton,
-  EuiButtonIcon,
   EuiContextMenu,
   EuiContextMenuPanelDescriptor,
   EuiFieldText,
@@ -22,7 +21,6 @@ import {
   EuiPopover,
   EuiSpacer,
   EuiSuperDatePicker,
-  EuiText,
   EuiTitle,
   OnTimeChangeProps,
   ShortDate,
@@ -63,7 +61,7 @@ import { PPLReferenceFlyout } from '../common/helpers';
  * setToast: create Toast function
  */
 
-type Props = {
+interface Props {
   panelId: string;
   page?: string;
   appId?: string;
@@ -84,7 +82,11 @@ type Props = {
     text?: React.ReactChild | undefined,
     side?: string | undefined
   ) => void;
-};
+  startTime: string;
+  endTime: string;
+  setStartTime: any;
+  setEndTime: any;
+}
 
 export const CustomPanelView = ({
   panelId,
@@ -95,6 +97,10 @@ export const CustomPanelView = ({
   pplService,
   chrome,
   parentBreadcrumb,
+  startTime,
+  endTime,
+  setStartTime,
+  setEndTime,
   renameCustomPanel,
   deleteCustomPanel,
   cloneCustomPanel,
@@ -109,10 +115,10 @@ export const CustomPanelView = ({
   const [addVizDisabled, setAddVizDisabled] = useState(false);
   const [editDisabled, setEditDisabled] = useState(false);
   const [dateDisabled, setDateDisabled] = useState(false);
-  const [panelVisualizations, setPanelVisualizations] = useState<Array<VisualizationType>>([]);
+  const [panelVisualizations, setPanelVisualizations] = useState<VisualizationType[]>([]);
   const [editMode, setEditMode] = useState(false);
   const [isModalVisible, setIsModalVisible] = useState(false); // Modal Toggle
-  const [modalLayout, setModalLayout] = useState(<EuiOverlayMask></EuiOverlayMask>); // Modal Layout
+  const [modalLayout, setModalLayout] = useState(<EuiOverlayMask />); // Modal Layout
   const [isVizPopoverOpen, setVizPopoverOpen] = useState(false); // Add Visualization Popover
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false); // Add Visualization Flyout
   const [isFlyoutReplacement, setisFlyoutReplacement] = useState<boolean | undefined>(false);
@@ -133,8 +139,6 @@ export const CustomPanelView = ({
 
   // DateTimePicker States
   const [recentlyUsedRanges, setRecentlyUsedRanges] = useState<DurationRange[]>([]);
-  const [start, setStart] = useState<ShortDate>('now-30m');
-  const [end, setEnd] = useState<ShortDate>('now');
 
   const getVizContextPanels = (closeVizPopover?: () => void) => {
     return [
@@ -175,8 +179,8 @@ export const CustomPanelView = ({
         setOpenPanelName(res.operationalPanel.name);
         setPanelCreatedTime(res.createdTimeMs);
         setPPLFilterValue(res.operationalPanel.queryFilter.query);
-        setStart(res.operationalPanel.timeRange.from);
-        setEnd(res.operationalPanel.timeRange.to);
+        setStartTime(startTime ? startTime : res.operationalPanel.timeRange.from);
+        setEndTime(endTime ? endTime : res.operationalPanel.timeRange.to);
         setPanelVisualizations(res.operationalPanel.visualizations);
       })
       .catch((err) => {
@@ -205,7 +209,7 @@ export const CustomPanelView = ({
   };
 
   const onKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') onRefreshFilters(start, end);
+    if (e.key === 'Enter') onRefreshFilters(startTime, endTime);
   };
 
   const onDatePickerChange = (props: OnTimeChangeProps) => {
@@ -214,8 +218,8 @@ export const CustomPanelView = ({
       props.end,
       recentlyUsedRanges,
       setRecentlyUsedRanges,
-      setStart,
-      setEnd
+      setStartTime,
+      setEndTime
     );
     onRefreshFilters(props.start, props.end);
   };
@@ -334,8 +338,8 @@ export const CustomPanelView = ({
     }
   };
 
-  const onRefreshFilters = (startTime: ShortDate, endTime: ShortDate) => {
-    if (!isDateValid(convertDateTime(startTime), convertDateTime(endTime, false), setToast)) {
+  const onRefreshFilters = (start: ShortDate, end: ShortDate) => {
+    if (!isDateValid(convertDateTime(start), convertDateTime(end, false), setToast)) {
       return;
     }
 
@@ -347,8 +351,8 @@ export const CustomPanelView = ({
       panelId: panelId,
       query: pplFilterValue,
       language: 'ppl',
-      to: endTime,
-      from: startTime,
+      to: end,
+      from: start,
     };
 
     http
@@ -413,8 +417,8 @@ export const CustomPanelView = ({
         panelId={panelId}
         closeFlyout={closeFlyout}
         pplFilterValue={pplFilterValue}
-        start={start}
-        end={end}
+        start={startTime}
+        end={endTime}
         setToast={setToast}
         http={http}
         pplService={pplService}
@@ -616,8 +620,8 @@ export const CustomPanelView = ({
               <EuiFlexItem grow={false}>
                 <EuiSuperDatePicker
                   dateFormat={uiSettingsService.get('dateFormat')}
-                  start={start}
-                  end={end}
+                  start={startTime}
+                  end={endTime}
                   onTimeChange={onDatePickerChange}
                   recentlyUsedRanges={recentlyUsedRanges}
                   isDisabled={dateDisabled}
@@ -640,8 +644,8 @@ export const CustomPanelView = ({
               setPanelVisualizations={setPanelVisualizations}
               editMode={editMode}
               pplService={pplService}
-              startTime={start}
-              endTime={end}
+              startTime={startTime}
+              endTime={endTime}
               onRefresh={onRefresh}
               cloneVisualization={cloneVisualization}
               pplFilterValue={pplFilterValue}

--- a/dashboards-observability/public/components/custom_panels/home.tsx
+++ b/dashboards-observability/public/components/custom_panels/home.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiBreadcrumb, EuiGlobalToastList, EuiLink } from '@elastic/eui';
+import { EuiBreadcrumb, EuiGlobalToastList, EuiLink, ShortDate } from '@elastic/eui';
 import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
 import _ from 'lodash';
 import React, { ReactChild, useState } from 'react';
@@ -49,6 +49,8 @@ export const Home = ({ http, chrome, parentBreadcrumb, pplService, renderProps }
   const [toasts, setToasts] = useState<Array<Toast>>([]);
   const [loading, setLoading] = useState(false);
   const [toastRightSide, setToastRightSide] = useState<boolean>(true);
+  const [start, setStart] = useState<ShortDate>('now-30m');
+  const [end, setEnd] = useState<ShortDate>('now');
 
   const setToast = (title: string, color = 'success', text?: ReactChild, side?: string) => {
     if (!text) text = '';
@@ -315,6 +317,10 @@ export const Home = ({ http, chrome, parentBreadcrumb, pplService, renderProps }
               cloneCustomPanel={cloneCustomPanel}
               deleteCustomPanel={deleteCustomPanel}
               setToast={setToast}
+              startTime={start}
+              endTime={end}
+              setStartTime={setStart}
+              setEndTime={setEnd}
             />
           );
         }}

--- a/dashboards-observability/public/components/explorer/explorer.tsx
+++ b/dashboards-observability/public/components/explorer/explorer.tsx
@@ -78,6 +78,8 @@ export const Explorer = ({
   searchBarConfigs,
   appId = '',
   addVisualizationToPanel,
+  startTime,
+  endTime,
 }: IExplorerProps) => {
   const dispatch = useDispatch();
   const requestParams = { tabId };
@@ -865,10 +867,12 @@ export const Explorer = ({
     }
   };
 
-  const dateRange = isEmpty(query.selectedDateRange)
-    ? ['now-15m', 'now']
-    : [query.selectedDateRange[0], query.selectedDateRange[1]];
-
+  const dateRange =
+    isEmpty(startTime) || isEmpty(endTime)
+      ? isEmpty(query.selectedDateRange)
+        ? ['now-15m', 'now']
+        : [query.selectedDateRange[0], query.selectedDateRange[1]]
+      : [startTime, endTime];
   return (
     <div className="dscAppContainer">
       <Search

--- a/dashboards-observability/public/components/explorer/explorer.tsx
+++ b/dashboards-observability/public/components/explorer/explorer.tsx
@@ -80,6 +80,8 @@ export const Explorer = ({
   addVisualizationToPanel,
   startTime,
   endTime,
+  setStartTime,
+  setEndTime,
 }: IExplorerProps) => {
   const dispatch = useDispatch();
   const requestParams = { tabId };
@@ -118,10 +120,10 @@ export const Explorer = ({
 
   // const SearchBar = searchBar;
   let minInterval = 'y';
-  const findAutoInterval = (startTime: string, endTime: string) => {
-    if (startTime?.length === 0 || endTime?.length === 0 || startTime === endTime) return 'd';
-    const momentStart = dateMath.parse(startTime)!;
-    const momentEnd = dateMath.parse(endTime)!;
+  const findAutoInterval = (start: string, end: string) => {
+    if (start?.length === 0 || end?.length === 0 || start === end) return 'd';
+    const momentStart = dateMath.parse(start)!;
+    const momentEnd = dateMath.parse(end)!;
     const diffSeconds = momentEnd.unix() - momentStart.unix();
 
     // less than 1 second
@@ -349,15 +351,20 @@ export const Explorer = ({
     toggleFields(field, SELECTED_FIELDS, AVAILABLE_FIELDS);
 
   const handleTimePickerChange = async (timeRange: string[]) => {
-    await dispatch(
-      changeDateRange({
-        tabId: requestParams.tabId,
-        data: {
-          [RAW_QUERY]: queryRef.current![RAW_QUERY],
-          [SELECTED_DATE_RANGE]: timeRange,
-        },
-      })
-    );
+    if (tabId === 'application-analytics-tab') {
+      setStartTime(timeRange[0]);
+      setEndTime(timeRange[1]);
+    } else {
+      await dispatch(
+        changeDateRange({
+          tabId: requestParams.tabId,
+          data: {
+            [RAW_QUERY]: queryRef.current![RAW_QUERY],
+            [SELECTED_DATE_RANGE]: timeRange,
+          },
+        })
+      );
+    }
   };
 
   const showPermissionErrorToast = () => {

--- a/dashboards-observability/public/components/explorer/slices/query_slice.ts
+++ b/dashboards-observability/public/components/explorer/slices/query_slice.ts
@@ -22,9 +22,17 @@ const initialQueryState = {
   [SELECTED_DATE_RANGE]: ['now-15m', 'now'],
 };
 
+const appBaseQueryState = {
+  [RAW_QUERY]: '',
+  [FINAL_QUERY]: '',
+  [INDEX]: '',
+  [SELECTED_TIMESTAMP]: '',
+  [SELECTED_DATE_RANGE]: ['now-24M', 'now'],
+};
+
 const initialState = {
   'application-analytics-tab': {
-    ...initialQueryState,
+    ...appBaseQueryState,
   },
   [initialTabId]: {
     ...initialQueryState,

--- a/dashboards-observability/server/adaptors/custom_panels/custom_panel_adaptor.ts
+++ b/dashboards-observability/server/adaptors/custom_panels/custom_panel_adaptor.ts
@@ -110,7 +110,7 @@ export class CustomPanelsAdaptor {
 
   // Create a new Panel
   createNewPanel = async (client: ILegacyScopedClusterClient, panelName: string, appId?: string) => {
-    var panelBody: PanelType = {
+    const panelBody: PanelType = {
       name: panelName,
       visualizations: [],
       timeRange: {
@@ -120,10 +120,14 @@ export class CustomPanelsAdaptor {
       queryFilter: {
         query: '',
         language: 'ppl',
-      }
+      },
     };
     if (appId) {
       panelBody.applicationId = appId;
+      panelBody.timeRange = {
+        to: 'now',
+        from: 'now-24M',
+      };
     }
 
     try {


### PR DESCRIPTION
### Description
- The default time range is changed to within the past 24 months
- The time range within an application is the same on all tabs
- Filters and changed time ranges are cleared when you arrive on the Application Analytics home page
- Update custom panel view snapshot to include start and end time props

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
