### PR TITLE
UI changes to Metrics Tab

### DIFF
--- a/dashboards-observability/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view.test.tsx.snap
+++ b/dashboards-observability/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view.test.tsx.snap
@@ -1143,7 +1143,8 @@ exports[`Panels View Component renders panel view container with visualizations 
                             className="euiTextAlign euiTextAlign--center"
                           >
                             <h2>
-                              Start by adding your first visualization
+                              Start by adding 
+                              your first visualization
                             </h2>
                             <EuiSpacer
                               size="m"
@@ -1166,7 +1167,8 @@ exports[`Panels View Component renders panel view container with visualizations 
                                   <div
                                     className="euiTextColor euiTextColor--subdued"
                                   >
-                                    Use PPL Queries to fetch & filter Observability Data and Create Visualizations
+                                    Use PPL Queries to fetch & filter observability data and create
+                                     visualizations
                                   </div>
                                 </EuiTextColor>
                               </div>
@@ -2772,7 +2774,8 @@ exports[`Panels View Component renders panel view container with visualizations 
                             className="euiTextAlign euiTextAlign--center"
                           >
                             <h2>
-                              Start by adding your first visualization
+                              Start by adding 
+                              your first visualization
                             </h2>
                             <EuiSpacer
                               size="m"
@@ -2795,7 +2798,8 @@ exports[`Panels View Component renders panel view container with visualizations 
                                   <div
                                     className="euiTextColor euiTextColor--subdued"
                                   >
-                                    Use PPL Queries to fetch & filter Observability Data and Create Visualizations
+                                    Use PPL Queries to fetch & filter observability data and create
+                                     visualizations
                                   </div>
                                 </EuiTextColor>
                               </div>
@@ -4345,7 +4349,8 @@ exports[`Panels View Component renders panel view container without visualizatio
                             className="euiTextAlign euiTextAlign--center"
                           >
                             <h2>
-                              Start by adding your first visualization
+                              Start by adding 
+                              your first visualization
                             </h2>
                             <EuiSpacer
                               size="m"
@@ -4368,7 +4373,8 @@ exports[`Panels View Component renders panel view container without visualizatio
                                   <div
                                     className="euiTextColor euiTextColor--subdued"
                                   >
-                                    Use PPL Queries to fetch & filter Observability Data and Create Visualizations
+                                    Use PPL Queries to fetch & filter observability data and create
+                                     visualizations
                                   </div>
                                 </EuiTextColor>
                               </div>

--- a/dashboards-observability/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view.test.tsx.snap
+++ b/dashboards-observability/public/components/custom_panels/__tests__/__snapshots__/custom_panel_view.test.tsx.snap
@@ -74,6 +74,7 @@ exports[`Panels View Component renders panel view container with visualizations 
   deleteCustomPanel={[MockFunction]}
   endTime="now"
   http={[MockFunction]}
+  page="operationalPanels"
   panelId="L8Sx53wBDp0rvEg3yoLb"
   parentBreadcrumb={
     Array [
@@ -1119,6 +1120,7 @@ exports[`Panels View Component renders panel view container with visualizations 
                 <EmptyPanelView
                   addVizDisabled={false}
                   getVizContextPanels={[Function]}
+                  page="operationalPanels"
                 >
                   <div>
                     <EuiSpacer
@@ -1673,6 +1675,7 @@ exports[`Panels View Component renders panel view container with visualizations 
   deleteCustomPanel={[MockFunction]}
   endTime="now"
   http={[MockFunction]}
+  page="operationalPanels"
   panelId="L8Sx53wBDp0rvEg3yoLb"
   parentBreadcrumb={
     Array [
@@ -2746,6 +2749,7 @@ exports[`Panels View Component renders panel view container with visualizations 
                 <EmptyPanelView
                   addVizDisabled={false}
                   getVizContextPanels={[Function]}
+                  page="operationalPanels"
                 >
                   <div>
                     <EuiSpacer
@@ -3300,6 +3304,7 @@ exports[`Panels View Component renders panel view container without visualizatio
   deleteCustomPanel={[MockFunction]}
   endTime="now"
   http={[MockFunction]}
+  page="operationalPanels"
   panelId="L8Sx53wBDp0rvEg3yoLb"
   parentBreadcrumb={
     Array [
@@ -4317,6 +4322,7 @@ exports[`Panels View Component renders panel view container without visualizatio
                 <EmptyPanelView
                   addVizDisabled={false}
                   getVizContextPanels={[Function]}
+                  page="operationalPanels"
                 >
                   <div>
                     <EuiSpacer

--- a/dashboards-observability/public/components/custom_panels/__tests__/custom_panel_view.test.tsx
+++ b/dashboards-observability/public/components/custom_panels/__tests__/custom_panel_view.test.tsx
@@ -56,6 +56,7 @@ describe('Panels View Component', () => {
         endTime={end}
         setStartTime={setStart}
         setEndTime={setEnd}
+        page="operationalPanels"
       />
     );
     wrapper.update();
@@ -108,6 +109,7 @@ describe('Panels View Component', () => {
         endTime={end}
         setStartTime={setStart}
         setEndTime={setEnd}
+        page="operationalPanels"
       />
     );
     wrapper.update();

--- a/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
+++ b/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
@@ -65,7 +65,7 @@ import { PPLReferenceFlyout } from '../common/helpers';
 
 interface Props {
   panelId: string;
-  page?: string;
+  page: 'app' | 'operationalPanels';
   appId?: string;
   appName?: string;
   http: CoreStart['http'];
@@ -623,20 +623,24 @@ export const CustomPanelView = ({
                   isDisabled={dateDisabled}
                 />
               </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiButton
-                  iconType="pencil"
-                  onClick={() => editPanel('edit')}
-                  disabled={editDisabled}
-                >
-                  Edit
-                </EuiButton>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <EuiButton isDisabled={addVizDisabled} onClick={switchToEvent}>
-                  Add
-                </EuiButton>
-              </EuiFlexItem>
+              {appMetrics && (
+                <>
+                  <EuiFlexItem grow={false}>
+                    <EuiButton
+                      iconType="pencil"
+                      onClick={() => editPanel('edit')}
+                      disabled={editDisabled}
+                    >
+                      Edit
+                    </EuiButton>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiButton isDisabled={addVizDisabled} onClick={switchToEvent}>
+                      Add
+                    </EuiButton>
+                  </EuiFlexItem>
+                </>
+              )}
             </EuiFlexGroup>
             <EuiSpacer size="l" />
             {panelVisualizations.length === 0 && (

--- a/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
+++ b/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
@@ -629,13 +629,17 @@ export const CustomPanelView = ({
                     <EuiButton
                       iconType="pencil"
                       onClick={() => editPanel('edit')}
-                      disabled={editDisabled}
+                      isDisabled={editDisabled}
                     >
                       Edit
                     </EuiButton>
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
-                    <EuiButton isDisabled={addVizDisabled} onClick={switchToEvent}>
+                    <EuiButton
+                      iconType="plusInCircle"
+                      onClick={switchToEvent}
+                      isDisabled={addVizDisabled}
+                    >
                       Add
                     </EuiButton>
                   </EuiFlexItem>

--- a/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
+++ b/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
@@ -131,6 +131,8 @@ export const CustomPanelView = ({
   const [editActionType, setEditActionType] = useState('');
   const [isHelpFlyoutVisible, setHelpIsFlyoutVisible] = useState(false);
 
+  const appMetrics = page === 'app';
+
   const closeHelpFlyout = () => {
     setAddVizDisabled(false);
     setHelpIsFlyoutVisible(false);
@@ -489,7 +491,7 @@ export const CustomPanelView = ({
   // Edit the breadcrumb when panel name changes
   useEffect(() => {
     let newBreadcrumb;
-    if (page === 'app') {
+    if (appMetrics) {
       newBreadcrumb = [
         ...parentBreadcrumb,
         {
@@ -518,46 +520,48 @@ export const CustomPanelView = ({
       <EuiPage>
         <EuiPageBody component="div">
           <EuiPageHeader>
-            <EuiPageHeaderSection>
-              <EuiTitle size="l">
-                <h1>{openPanelName}</h1>
-              </EuiTitle>
-              <EuiFlexItem>
-                <EuiSpacer size="s" />
-              </EuiFlexItem>
-              Created on {moment(panelCreatedTime).format(UI_DATE_FORMAT)}
-            </EuiPageHeaderSection>
-            <EuiPageHeaderSection>
-              <EuiFlexGroup gutterSize="s">
-                {editMode ? (
-                  <>
+            {appMetrics || (
+              <EuiPageHeaderSection>
+                <EuiTitle size="l">
+                  <h1>{openPanelName}</h1>
+                </EuiTitle>
+                <EuiFlexItem>
+                  <EuiSpacer size="s" />
+                </EuiFlexItem>
+                Created on {moment(panelCreatedTime).format(UI_DATE_FORMAT)}
+              </EuiPageHeaderSection>
+            )}
+            {appMetrics || (
+              <EuiPageHeaderSection>
+                <EuiFlexGroup gutterSize="s">
+                  {editMode ? (
+                    <>
+                      <EuiFlexItem>
+                        <EuiButton
+                          iconType="cross"
+                          color="danger"
+                          onClick={() => editPanel('cancel')}
+                        >
+                          Cancel
+                        </EuiButton>
+                      </EuiFlexItem>
+                      <EuiFlexItem>
+                        <EuiButton iconType="save" onClick={() => editPanel('save')}>
+                          Save
+                        </EuiButton>
+                      </EuiFlexItem>
+                    </>
+                  ) : (
                     <EuiFlexItem>
                       <EuiButton
-                        iconType="cross"
-                        color="danger"
-                        onClick={() => editPanel('cancel')}
+                        iconType="pencil"
+                        onClick={() => editPanel('edit')}
+                        disabled={editDisabled}
                       >
-                        Cancel
+                        Edit
                       </EuiButton>
                     </EuiFlexItem>
-                    <EuiFlexItem>
-                      <EuiButton iconType="save" onClick={() => editPanel('save')}>
-                        Save
-                      </EuiButton>
-                    </EuiFlexItem>
-                  </>
-                ) : (
-                  <EuiFlexItem>
-                    <EuiButton
-                      iconType="pencil"
-                      onClick={() => editPanel('edit')}
-                      disabled={editDisabled}
-                    >
-                      Edit
-                    </EuiButton>
-                  </EuiFlexItem>
-                )}
-                {page === 'app' || (
+                  )}
                   <EuiFlexItem grow={false}>
                     <EuiPopover
                       panelPaddingSize="none"
@@ -569,14 +573,6 @@ export const CustomPanelView = ({
                       <EuiContextMenu initialPanelId={0} panels={panelActionsMenu} />
                     </EuiPopover>
                   </EuiFlexItem>
-                )}
-                {page === 'app' ? (
-                  <EuiFlexItem grow={false}>
-                    <EuiButton isDisabled={addVizDisabled} onClick={switchToEvent}>
-                      Add Visualization
-                    </EuiButton>
-                  </EuiFlexItem>
-                ) : (
                   <EuiFlexItem grow={false}>
                     <EuiPopover
                       id="addVisualizationContextMenu"
@@ -592,9 +588,9 @@ export const CustomPanelView = ({
                       />
                     </EuiPopover>
                   </EuiFlexItem>
-                )}
-              </EuiFlexGroup>
-            </EuiPageHeaderSection>
+                </EuiFlexGroup>
+              </EuiPageHeaderSection>
+            )}
           </EuiPageHeader>
           <EuiPageContentBody>
             <EuiFlexGroup gutterSize="s">
@@ -626,6 +622,20 @@ export const CustomPanelView = ({
                   recentlyUsedRanges={recentlyUsedRanges}
                   isDisabled={dateDisabled}
                 />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButton
+                  iconType="pencil"
+                  onClick={() => editPanel('edit')}
+                  disabled={editDisabled}
+                >
+                  Edit
+                </EuiButton>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButton isDisabled={addVizDisabled} onClick={switchToEvent}>
+                  Add
+                </EuiButton>
               </EuiFlexItem>
             </EuiFlexGroup>
             <EuiSpacer size="l" />

--- a/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
+++ b/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
@@ -640,7 +640,7 @@ export const CustomPanelView = ({
                       onClick={switchToEvent}
                       isDisabled={addVizDisabled}
                     >
-                      Add
+                      Add metric
                     </EuiButton>
                   </EuiFlexItem>
                 </>

--- a/dashboards-observability/public/components/custom_panels/home.tsx
+++ b/dashboards-observability/public/components/custom_panels/home.tsx
@@ -321,6 +321,7 @@ export const Home = ({ http, chrome, parentBreadcrumb, pplService, renderProps }
               endTime={end}
               setStartTime={setStart}
               setEndTime={setEnd}
+              page="operationalPanels"
             />
           );
         }}

--- a/dashboards-observability/public/components/custom_panels/panel_modules/__tests__/__snapshots__/empty_panel.test.tsx.snap
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/__tests__/__snapshots__/empty_panel.test.tsx.snap
@@ -41,7 +41,8 @@ exports[`Empty panel view component renders empty panel view with disabled popov
             className="euiTextAlign euiTextAlign--center"
           >
             <h2>
-              Start by adding your first visualization
+              Start by adding 
+              your first visualization
             </h2>
             <EuiSpacer
               size="m"
@@ -64,7 +65,8 @@ exports[`Empty panel view component renders empty panel view with disabled popov
                   <div
                     className="euiTextColor euiTextColor--subdued"
                   >
-                    Use PPL Queries to fetch & filter Observability Data and Create Visualizations
+                    Use PPL Queries to fetch & filter observability data and create
+                     visualizations
                   </div>
                 </EuiTextColor>
               </div>
@@ -257,7 +259,8 @@ exports[`Empty panel view component renders empty panel view with enabled popove
             className="euiTextAlign euiTextAlign--center"
           >
             <h2>
-              Start by adding your first visualization
+              Start by adding 
+              your first visualization
             </h2>
             <EuiSpacer
               size="m"
@@ -280,7 +283,8 @@ exports[`Empty panel view component renders empty panel view with enabled popove
                   <div
                     className="euiTextColor euiTextColor--subdued"
                   >
-                    Use PPL Queries to fetch & filter Observability Data and Create Visualizations
+                    Use PPL Queries to fetch & filter observability data and create
+                     visualizations
                   </div>
                 </EuiTextColor>
               </div>

--- a/dashboards-observability/public/components/custom_panels/panel_modules/__tests__/__snapshots__/empty_panel.test.tsx.snap
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/__tests__/__snapshots__/empty_panel.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`Empty panel view component renders empty panel view with disabled popov
       ],
     }
   }
+  page="operationalPanel"
 >
   <div>
     <EuiSpacer
@@ -233,6 +234,7 @@ exports[`Empty panel view component renders empty panel view with enabled popove
       ],
     }
   }
+  page="operationalPanel"
 >
   <div>
     <EuiSpacer

--- a/dashboards-observability/public/components/custom_panels/panel_modules/__tests__/empty_panel.test.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/__tests__/empty_panel.test.tsx
@@ -14,7 +14,11 @@ describe('Empty panel view component', () => {
   it('renders empty panel view with disabled popover', () => {
     const getVizContextPanels = jest.fn();
     const wrapper = mount(
-      <EmptyPanelView addVizDisabled={true} getVizContextPanels={getVizContextPanels} />
+      <EmptyPanelView
+        page="operationalPanel"
+        addVizDisabled={true}
+        getVizContextPanels={getVizContextPanels}
+      />
     );
 
     expect(wrapper).toMatchSnapshot();
@@ -24,11 +28,14 @@ describe('Empty panel view component', () => {
   it('renders empty panel view with enabled popover', () => {
     const getVizContextPanels = jest.fn();
     const wrapper = mount(
-      <EmptyPanelView addVizDisabled={false} getVizContextPanels={getVizContextPanels} />
+      <EmptyPanelView
+        page="operationalPanel"
+        addVizDisabled={false}
+        getVizContextPanels={getVizContextPanels}
+      />
     );
 
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find('EuiButton').prop('disabled')).toBe(false);
   });
-
 });

--- a/dashboards-observability/public/components/custom_panels/panel_modules/empty_panel.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/empty_panel.tsx
@@ -24,7 +24,7 @@ import React, { useState } from 'react';
 
 interface Props {
   addVizDisabled: boolean;
-  page?: string;
+  page: 'app' | 'operationalPanel';
   getVizContextPanels: (
     closeVizPopover?: (() => void) | undefined
   ) => Array<{

--- a/dashboards-observability/public/components/custom_panels/panel_modules/empty_panel.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/empty_panel.tsx
@@ -45,6 +45,7 @@ export const EmptyPanelView = ({
   switchToEvent,
 }: Props) => {
   const [isVizPopoverOpen, setVizPopoverOpen] = useState(false);
+  const appMetrics = page === 'app';
 
   const onPopoverClick = () => {
     setVizPopoverOpen(!isVizPopoverOpen);
@@ -70,18 +71,19 @@ export const EmptyPanelView = ({
     <div>
       <EuiSpacer size="xxl" />
       <EuiText textAlign="center">
-        <h2>Start by adding your first visualization</h2>
+        <h2>Start by adding {appMetrics ? 'metrics' : 'your first visualization'}</h2>
         <EuiSpacer size="m" />
         <EuiText color="subdued" size="m">
-          Use PPL Queries to fetch &amp; filter Observability Data and Create Visualizations
+          Use PPL Queries to fetch &amp; filter observability data and create
+          {appMetrics ? ' metrics' : ' visualizations'}
         </EuiText>
       </EuiText>
       <EuiSpacer size="m" />
       <EuiFlexGroup justifyContent="center">
-        {page === 'app' ? (
+        {appMetrics ? (
           <EuiFlexItem grow={false}>
             <EuiButton iconType="plusInCircle" onClick={switchToEvent} isDisabled={addVizDisabled}>
-              Add
+              Add metric
             </EuiButton>
           </EuiFlexItem>
         ) : (

--- a/dashboards-observability/public/components/custom_panels/panel_modules/empty_panel.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/empty_panel.tsx
@@ -80,8 +80,8 @@ export const EmptyPanelView = ({
       <EuiFlexGroup justifyContent="center">
         {page === 'app' ? (
           <EuiFlexItem grow={false}>
-            <EuiButton isDisabled={addVizDisabled} onClick={switchToEvent}>
-              Add Visualization
+            <EuiButton iconType="plusInCircle" onClick={switchToEvent} isDisabled={addVizDisabled}>
+              Add
             </EuiButton>
           </EuiFlexItem>
         ) : (


### PR DESCRIPTION
Signed-off-by: Eugene Lee <eugenesk@amazon.com>

### Description
- Hides panel name on Metrics Tab.
- Moves search bar up on Metrics Tab.
- Change `Add Visualization` button to `Add`
- Add plus icon in Add button

![Screen Shot 2022-02-16 at 3 59 43 PM](https://user-images.githubusercontent.com/92330893/154377862-37cc4fba-133c-4478-84d6-05a9654a901f.png)


### Issues Resolved
Closes #463 
Closes #464 
Closes #465 
Closes #466 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
