### PR TITLE
Redirect to trace tab, updateMappings once, etc

### DIFF
--- a/dashboards-observability/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
+++ b/dashboards-observability/public/components/application_analytics/__tests__/__snapshots__/service_config.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`Service Config component renders empty service config 1`] = `
 <ServiceConfig
+  appConfigs={Array []}
   chrome={
     Object {
       "getIsNavDrawerLocked$": [MockFunction],
@@ -30,8 +31,10 @@ exports[`Service Config component renders empty service config 1`] = `
   }
   query=""
   selectedServices={Array []}
+  setAppConfigs={[MockFunction]}
   setDescriptionWithStorage={[MockFunction]}
   setEndTime={[MockFunction]}
+  setEndTimeWithStorage={[MockFunction]}
   setFilters={[MockFunction]}
   setFiltersWithStorage={[MockFunction]}
   setNameWithStorage={[MockFunction]}
@@ -53,6 +56,7 @@ exports[`Service Config component renders empty service config 1`] = `
     }
   }
   setStartTime={[MockFunction]}
+  setStartTimeWithStorage={[MockFunction]}
   startTime="now-5m"
 >
   <div>
@@ -512,6 +516,7 @@ exports[`Service Config component renders empty service config 1`] = `
                 <ServiceMap
                   addFilter={[Function]}
                   idSelected="latency"
+                  page="appCreate"
                   serviceMap={Object {}}
                   setIdSelected={[Function]}
                 >
@@ -1048,6 +1053,7 @@ exports[`Service Config component renders empty service config 1`] = `
 
 exports[`Service Config component renders with one service selected 1`] = `
 <ServiceConfig
+  appConfigs={Array []}
   chrome={
     Object {
       "getIsNavDrawerLocked$": [MockFunction],
@@ -1086,8 +1092,10 @@ exports[`Service Config component renders with one service selected 1`] = `
   }
   query=""
   selectedServices={Array []}
+  setAppConfigs={[MockFunction]}
   setDescriptionWithStorage={[MockFunction]}
   setEndTime={[MockFunction]}
+  setEndTimeWithStorage={[MockFunction]}
   setFilters={[MockFunction]}
   setFiltersWithStorage={[MockFunction]}
   setNameWithStorage={[MockFunction]}
@@ -1113,6 +1121,7 @@ exports[`Service Config component renders with one service selected 1`] = `
     }
   }
   setStartTime={[MockFunction]}
+  setStartTimeWithStorage={[MockFunction]}
   startTime="now-5m"
 >
   <div>
@@ -1582,6 +1591,7 @@ exports[`Service Config component renders with one service selected 1`] = `
                 <ServiceMap
                   addFilter={[Function]}
                   idSelected="latency"
+                  page="appCreate"
                   serviceMap={Object {}}
                   setIdSelected={[Function]}
                 >

--- a/dashboards-observability/public/components/application_analytics/__tests__/service_config.test.tsx
+++ b/dashboards-observability/public/components/application_analytics/__tests__/service_config.test.tsx
@@ -60,7 +60,6 @@ describe('Service Config component', () => {
         setAppConfigs={setAppConfigs}
         setStartTimeWithStorage={setStartTimeWithStorage}
         setEndTimeWithStorage={setEndTimeWithStorage}
-        page="appCreate"
       />
     );
 
@@ -123,7 +122,6 @@ describe('Service Config component', () => {
         setAppConfigs={setAppConfigs}
         setStartTimeWithStorage={setStartTimeWithStorage}
         setEndTimeWithStorage={setEndTimeWithStorage}
-        page="appCreate"
       />
     );
 

--- a/dashboards-observability/public/components/application_analytics/__tests__/service_config.test.tsx
+++ b/dashboards-observability/public/components/application_analytics/__tests__/service_config.test.tsx
@@ -24,6 +24,9 @@ describe('Service Config component', () => {
     const setDescriptionWithStorage = jest.fn();
     const setQueryWithStorage = jest.fn();
     const setFiltersWithStorage = jest.fn();
+    const setAppConfigs = jest.fn();
+    const setStartTimeWithStorage = jest.fn();
+    const setEndTimeWithStorage = jest.fn();
     const dslService = ({
       http: jest.fn(),
       fetch: jest.fn(),
@@ -53,6 +56,11 @@ describe('Service Config component', () => {
         setDescriptionWithStorage={setDescriptionWithStorage}
         setQueryWithStorage={setQueryWithStorage}
         setFiltersWithStorage={setFiltersWithStorage}
+        appConfigs={[]}
+        setAppConfigs={setAppConfigs}
+        setStartTimeWithStorage={setStartTimeWithStorage}
+        setEndTimeWithStorage={setEndTimeWithStorage}
+        page="appCreate"
       />
     );
 
@@ -70,6 +78,9 @@ describe('Service Config component', () => {
     const setDescriptionWithStorage = jest.fn();
     const setQueryWithStorage = jest.fn();
     const setFiltersWithStorage = jest.fn();
+    const setAppConfigs = jest.fn();
+    const setStartTimeWithStorage = jest.fn();
+    const setEndTimeWithStorage = jest.fn();
     const dslService = ({
       http: jest.fn(),
       fetch: jest.fn(),
@@ -108,6 +119,11 @@ describe('Service Config component', () => {
         setDescriptionWithStorage={setDescriptionWithStorage}
         setQueryWithStorage={setQueryWithStorage}
         setFiltersWithStorage={setFiltersWithStorage}
+        appConfigs={[]}
+        setAppConfigs={setAppConfigs}
+        setStartTimeWithStorage={setStartTimeWithStorage}
+        setEndTimeWithStorage={setEndTimeWithStorage}
+        page="appCreate"
       />
     );
 

--- a/dashboards-observability/public/components/application_analytics/components/application.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/application.tsx
@@ -236,8 +236,13 @@ export function Application(props: AppDetailProps) {
         openServiceFlyout={openServiceFlyout}
         setStartTime={setStartTimeForApp}
         setEndTime={setEndTimeForApp}
+        switchToTrace={switchToTrace}
       />
     );
+  };
+
+  const switchToTrace = () => {
+    setSelectedTab(TAB_TRACE_ID);
   };
 
   const getTrace = () => {

--- a/dashboards-observability/public/components/application_analytics/components/application.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/application.tsx
@@ -438,6 +438,7 @@ export function Application(props: AppDetailProps) {
             http={http}
             traceId={traceFlyoutId}
             closeTraceFlyout={closeTraceFlyout}
+            openSpanFlyout={openSpanFlyout}
           />
         )}
       </EuiPage>

--- a/dashboards-observability/public/components/application_analytics/components/config_components/service_config.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/config_components/service_config.tsx
@@ -179,7 +179,7 @@ export const ServiceConfig = (props: ServiceConfigProps) => {
           idSelected={serviceMapIdSelected}
           setIdSelected={setServiceMapIdSelected}
           addFilter={addFilter}
-          page={'appCreate'}
+          page="appCreate"
         />
       </EuiAccordion>
       {isModalVisible && modalLayout}

--- a/dashboards-observability/public/components/application_analytics/components/config_components/service_config.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/config_components/service_config.tsx
@@ -29,6 +29,7 @@ interface ServiceConfigProps extends AppAnalyticsComponentDeps {
   dslService: DSLService;
   selectedServices: OptionType[];
   setSelectedServices: (services: OptionType[]) => void;
+  page?: string;
 }
 
 export const ServiceConfig = (props: ServiceConfigProps) => {
@@ -39,6 +40,7 @@ export const ServiceConfig = (props: ServiceConfigProps) => {
     http,
     selectedServices,
     setSelectedServices,
+    page,
   } = props;
   const [servicesOpen, setServicesOpen] = useState(false);
   const [serviceMap, setServiceMap] = useState<ServiceObject>({});
@@ -179,6 +181,7 @@ export const ServiceConfig = (props: ServiceConfigProps) => {
           idSelected={serviceMapIdSelected}
           setIdSelected={setServiceMapIdSelected}
           addFilter={addFilter}
+          page={page}
         />
       </EuiAccordion>
       {isModalVisible && modalLayout}

--- a/dashboards-observability/public/components/application_analytics/components/config_components/service_config.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/config_components/service_config.tsx
@@ -29,7 +29,6 @@ interface ServiceConfigProps extends AppAnalyticsComponentDeps {
   dslService: DSLService;
   selectedServices: OptionType[];
   setSelectedServices: (services: OptionType[]) => void;
-  page?: string;
 }
 
 export const ServiceConfig = (props: ServiceConfigProps) => {
@@ -40,7 +39,6 @@ export const ServiceConfig = (props: ServiceConfigProps) => {
     http,
     selectedServices,
     setSelectedServices,
-    page,
   } = props;
   const [servicesOpen, setServicesOpen] = useState(false);
   const [serviceMap, setServiceMap] = useState<ServiceObject>({});
@@ -181,7 +179,7 @@ export const ServiceConfig = (props: ServiceConfigProps) => {
           idSelected={serviceMapIdSelected}
           setIdSelected={setServiceMapIdSelected}
           addFilter={addFilter}
-          page={page}
+          page={'appCreate'}
         />
       </EuiAccordion>
       {isModalVisible && modalLayout}

--- a/dashboards-observability/public/components/application_analytics/components/create.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/create.tsx
@@ -206,6 +206,7 @@ export const CreateApp = (props: CreateAppProps) => {
             <ServiceConfig
               selectedServices={selectedServices}
               setSelectedServices={setSelectedServices}
+              page={'appCreate'}
               {...props}
             />
             <EuiHorizontalRule />

--- a/dashboards-observability/public/components/application_analytics/components/create.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/create.tsx
@@ -206,7 +206,6 @@ export const CreateApp = (props: CreateAppProps) => {
             <ServiceConfig
               selectedServices={selectedServices}
               setSelectedServices={setSelectedServices}
-              page={'appCreate'}
               {...props}
             />
             <EuiHorizontalRule />

--- a/dashboards-observability/public/components/application_analytics/components/flyout_components/service_detail_flyout.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/flyout_components/service_detail_flyout.tsx
@@ -95,7 +95,7 @@ export function ServiceDetailFlyout(props: ServiceFlyoutProps) {
           idSelected={serviceMapIdSelected}
           setIdSelected={setServiceMapIdSelected}
           currService={serviceName}
-          page={'detailFlyout'}
+          page="detailFlyout"
         />
         <EuiSpacer size="xs" />
         <EuiHorizontalRule margin="s" />

--- a/dashboards-observability/public/components/application_analytics/components/flyout_components/service_detail_flyout.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/flyout_components/service_detail_flyout.tsx
@@ -95,6 +95,7 @@ export function ServiceDetailFlyout(props: ServiceFlyoutProps) {
           idSelected={serviceMapIdSelected}
           setIdSelected={setServiceMapIdSelected}
           currService={serviceName}
+          page={'detailFlyout'}
         />
         <EuiSpacer size="xs" />
         <EuiHorizontalRule margin="s" />

--- a/dashboards-observability/public/components/application_analytics/components/flyout_components/trace_detail_flyout.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/flyout_components/trace_detail_flyout.tsx
@@ -29,10 +29,11 @@ import { SpanDetailPanel } from '../../../../../public/components/trace_analytic
 interface TraceFlyoutProps extends TraceAnalyticsComponentDeps {
   traceId: string;
   closeTraceFlyout: () => void;
+  openSpanFlyout: (spanId: string) => void;
 }
 
 export function TraceDetailFlyout(props: TraceFlyoutProps) {
-  const { traceId, http, closeTraceFlyout } = props;
+  const { traceId, http, closeTraceFlyout, openSpanFlyout } = props;
   const [fields, setFields] = useState<any>({});
   const [serviceBreakdownData, setServiceBreakdownData] = useState([]);
   const [payloadData, setPayloadData] = useState('');
@@ -71,7 +72,13 @@ export function TraceDetailFlyout(props: TraceFlyoutProps) {
         <ServiceBreakdownPanel data={serviceBreakdownData} />
         <EuiSpacer size="xs" />
         <EuiHorizontalRule margin="s" />
-        <SpanDetailPanel traceId={traceId} http={http} colorMap={colorMap} />
+        <SpanDetailPanel
+          traceId={traceId}
+          http={http}
+          colorMap={colorMap}
+          page="app"
+          openSpanFlyout={openSpanFlyout}
+        />
         <EuiSpacer size="xs" />
         <EuiHorizontalRule margin="s" />
         <EuiText size="m">

--- a/dashboards-observability/public/components/custom_panels/panel_modules/empty_panel.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/empty_panel.tsx
@@ -24,7 +24,7 @@ import React, { useState } from 'react';
 
 interface Props {
   addVizDisabled: boolean;
-  page: 'app' | 'operationalPanel';
+  page: 'app' | 'operationalPanels';
   getVizContextPanels: (
     closeVizPopover?: (() => void) | undefined
   ) => Array<{

--- a/dashboards-observability/public/components/explorer/explorer.tsx
+++ b/dashboards-observability/public/components/explorer/explorer.tsx
@@ -341,7 +341,7 @@ export const Explorer = ({
   useEffect(() => {
     if (queryRef.current!.isLoaded) return;
     let objectId;
-    if (queryRef.current![TAB_CREATED_TYPE] === NEW_TAB) {
+    if (queryRef.current![TAB_CREATED_TYPE] === NEW_TAB || appLogEvents) {
       objectId = queryRef.current!.savedObjectId || '';
     } else {
       objectId = queryRef.current!.savedObjectId || savedObjectId;

--- a/dashboards-observability/public/components/trace_analytics/components/common/plots/__tests__/service_map.test.tsx
+++ b/dashboards-observability/public/components/trace_analytics/components/common/plots/__tests__/service_map.test.tsx
@@ -19,6 +19,7 @@ describe('Service map component', () => {
         serviceMap={TEST_SERVICE_MAP}
         idSelected="latency"
         setIdSelected={setServiceMapIdSelected}
+        page="dashboard"
       />
     );
     expect(wrapper).toMatchSnapshot();

--- a/dashboards-observability/public/components/trace_analytics/components/common/plots/service_map.tsx
+++ b/dashboards-observability/public/components/trace_analytics/components/common/plots/service_map.tsx
@@ -45,7 +45,7 @@ export function ServiceMap({
   setIdSelected,
   addFilter,
   currService,
-  page
+  page,
 }: {
   serviceMap: ServiceObject;
   idSelected: 'latency' | 'error_rate' | 'throughput';
@@ -121,7 +121,9 @@ export function ServiceMap({
           inverted: false,
           disabled: false,
         });
-        window.scrollTo({ left: 0, top: 0, behavior: 'smooth' });
+        if (page !== 'appCreate') {
+          window.scrollTo({ left: 0, top: 0, behavior: 'smooth' });
+        }
       }
     },
     hoverNode: (event: any) => {},
@@ -162,11 +164,11 @@ export function ServiceMap({
   return (
     <>
       <EuiPanel>
-        {page === "app" ?
+        {page === 'app' ? (
           <PanelTitle title="Application Composition Map" />
-        :
+        ) : (
           <PanelTitle title="Service map" />
-        }
+        )}
         <EuiSpacer size="m" />
         <EuiButtonGroup
           options={toggleButtons}

--- a/dashboards-observability/public/components/trace_analytics/components/common/plots/service_map.tsx
+++ b/dashboards-observability/public/components/trace_analytics/components/common/plots/service_map.tsx
@@ -52,7 +52,7 @@ export function ServiceMap({
   setIdSelected: (newId: 'latency' | 'error_rate' | 'throughput') => void;
   addFilter?: (filter: FilterType) => void;
   currService?: string;
-  page?: string;
+  page: 'app' | 'appCreate' | 'dashboard' | 'traces' | 'services' | 'serviceView' | 'detailFlyout';
 }) {
   const [invalid, setInvalid] = useState(false);
   const [network, setNetwork] = useState(null);

--- a/dashboards-observability/public/components/trace_analytics/components/services/__tests__/__snapshots__/service_view.test.tsx.snap
+++ b/dashboards-observability/public/components/trace_analytics/components/services/__tests__/__snapshots__/service_view.test.tsx.snap
@@ -219,6 +219,7 @@ exports[`Service view component renders service view 1`] = `
       <ServiceMap
         currService="order"
         idSelected="latency"
+        page="serviceView"
         serviceMap={Object {}}
         setIdSelected={[Function]}
       />

--- a/dashboards-observability/public/components/trace_analytics/components/services/service_view.tsx
+++ b/dashboards-observability/public/components/trace_analytics/components/services/service_view.tsx
@@ -314,6 +314,7 @@ export function ServiceView(props: ServiceViewProps) {
             idSelected={serviceMapIdSelected}
             setIdSelected={setServiceMapIdSelected}
             currService={props.serviceName}
+            page="serviceView"
           />
           <EuiSpacer />
           <EuiPanel>

--- a/dashboards-observability/public/components/trace_analytics/components/services/services.tsx
+++ b/dashboards-observability/public/components/trace_analytics/components/services/services.tsx
@@ -17,6 +17,7 @@ interface ServicesProps extends TraceAnalyticsComponentDeps {
   appId?: string;
   appName?: string;
   openServiceFlyout?: (serviceName: string) => void;
+  switchToTrace?: () => void;
   page: 'dashboard' | 'traces' | 'services' | 'app';
 }
 
@@ -129,6 +130,7 @@ export function Services(props: ServicesProps) {
         loading={loading}
         page={page}
         openServiceFlyout={props.openServiceFlyout}
+        switchToTrace={props.switchToTrace}
       />
     </>
   );

--- a/dashboards-observability/public/components/trace_analytics/components/services/services_table.tsx
+++ b/dashboards-observability/public/components/trace_analytics/components/services/services_table.tsx
@@ -35,7 +35,9 @@ export function ServicesTable(props: {
   loading: boolean;
   page?: string;
   openServiceFlyout?: any;
+  switchToTrace?: any;
 }) {
+  const appServices = props.page === 'app';
   const renderTitleBar = (totalItems?: number) => {
     return (
       <EuiFlexGroup alignItems="center" gutterSize="s">
@@ -55,7 +57,7 @@ export function ServicesTable(props: {
           align: 'left',
           sortable: true,
           render: (item) =>
-            props.page === 'app' ? (
+            appServices ? (
               <EuiLink onClick={() => props.openServiceFlyout(item)}>
                 {item.length < 24 ? (
                   item
@@ -127,27 +129,25 @@ export function ServicesTable(props: {
           render: (item, row) => (
             <>
               {item === 0 || item ? (
-                props.page === 'app' ? (
-                  <EuiLink>
-                    <EuiI18nNumber value={item} />
-                  </EuiLink>
-                ) : (
-                  <EuiLink
-                    onClick={() => {
-                      props.setRedirect(true);
-                      props.addFilter({
-                        field: 'serviceName',
-                        operator: 'is',
-                        value: row.name,
-                        inverted: false,
-                        disabled: false,
-                      });
+                <EuiLink
+                  onClick={() => {
+                    props.setRedirect(true);
+                    props.addFilter({
+                      field: 'serviceName',
+                      operator: 'is',
+                      value: row.name,
+                      inverted: false,
+                      disabled: false,
+                    });
+                    if (appServices) {
+                      props.switchToTrace();
+                    } else {
                       location.assign('#/trace_analytics/traces');
-                    }}
-                  >
-                    <EuiI18nNumber value={item} />
-                  </EuiLink>
-                )
+                    }
+                  }}
+                >
+                  <EuiI18nNumber value={item} />
+                </EuiLink>
               ) : (
                 '-'
               )}

--- a/dashboards-observability/public/components/trace_analytics/components/traces/span_detail_panel.tsx
+++ b/dashboards-observability/public/components/trace_analytics/components/traces/span_detail_panel.tsx
@@ -27,9 +27,11 @@ export function SpanDetailPanel(props: {
   traceId: string;
   colorMap: any;
   page?: string;
+  openSpanFlyout?: any;
 }) {
   const [data, setData] = useState({ gantt: [], table: [], ganttMaxX: 0 });
   const storedFilters = sessionStorage.getItem('TraceAnalyticsSpanFilters');
+  const fromApp = props.page === 'app';
   const [spanFilters, setSpanFilters] = useState<Array<{ field: string; value: any }>>(
     storedFilters ? JSON.parse(storedFilters) : []
   );
@@ -142,7 +144,11 @@ export function SpanDetailPanel(props: {
   const onClick = (event: any) => {
     if (!event?.points) return;
     const point = event.points[0];
-    setCurrentSpan(point.data.spanId);
+    if (fromApp) {
+      props.openSpanFlyout(point.data.spanId);
+    } else {
+      setCurrentSpan(point.data.spanId);
+    }
   };
 
   const renderFilters = useMemo(() => {
@@ -188,7 +194,13 @@ export function SpanDetailPanel(props: {
         http={props.http}
         hiddenColumns={['traceId', 'traceGroup']}
         DSL={DSL}
-        openFlyout={(spanId: string) => setCurrentSpan(spanId)}
+        openFlyout={(spanId: string) => {
+          if (fromApp) {
+            props.openSpanFlyout(spanId);
+          } else {
+            setCurrentSpan(spanId);
+          }
+        }}
       />
     ),
     [DSL, setCurrentSpan]

--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/index/ObservabilityIndex.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/index/ObservabilityIndex.kt
@@ -56,9 +56,9 @@ internal object ObservabilityIndex {
     private const val OBSERVABILITY_SETTINGS_FILE_NAME = "observability-settings.yml"
     private const val MAPPING_TYPE = "_doc"
 
+    private var mappingsUpdated: Boolean = false
     private lateinit var client: Client
     private lateinit var clusterService: ClusterService
-    private var mappingsUpdated: Boolean = false
 
     private val searchHitParser = object : SearchResults.SearchHitParser<ObservabilityObjectDoc> {
         override fun parse(searchHit: SearchHit): ObservabilityObjectDoc {

--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/index/ObservabilityIndex.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/index/ObservabilityIndex.kt
@@ -58,6 +58,7 @@ internal object ObservabilityIndex {
 
     private lateinit var client: Client
     private lateinit var clusterService: ClusterService
+    private var mappingsUpdated: Boolean = false
 
     private val searchHitParser = object : SearchResults.SearchHitParser<ObservabilityObjectDoc> {
         override fun parse(searchHit: SearchHit): ObservabilityObjectDoc {
@@ -79,6 +80,7 @@ internal object ObservabilityIndex {
     fun initialize(client: Client, clusterService: ClusterService) {
         this.client = SecureIndexClient(client)
         this.clusterService = clusterService
+        this.mappingsUpdated = false
     }
 
     /**
@@ -86,10 +88,7 @@ internal object ObservabilityIndex {
      */
     @Suppress("TooGenericExceptionCaught")
     private fun createIndex() {
-        if (isIndexExists(INDEX_NAME)) {
-            // TODO: Only update mappings when they have changed so it doesn't run on every request
-            updateMappings()
-        } else {
+        if (!isIndexExists(INDEX_NAME)) {
             val classLoader = ObservabilityIndex::class.java.classLoader
             val indexMappingSource = classLoader.getResource(OBSERVABILITY_MAPPING_FILE_NAME)?.readText()!!
             val indexSettingsSource = classLoader.getResource(OBSERVABILITY_SETTINGS_FILE_NAME)?.readText()!!
@@ -111,6 +110,9 @@ internal object ObservabilityIndex {
                 }
             }
         }
+        if (!this.mappingsUpdated) {
+            updateMappings()
+        }
     }
 
     /**
@@ -130,6 +132,7 @@ internal object ObservabilityIndex {
             } else {
                 throw IllegalStateException("$LOG_PREFIX:Index $INDEX_NAME update mapping not Acknowledged")
             }
+            this.mappingsUpdated = true
         } catch (exception: IndexNotFoundException) {
             log.error("$LOG_PREFIX:IndexNotFoundException:", exception)
         }

--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/index/ObservabilityIndex.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/index/ObservabilityIndex.kt
@@ -109,8 +109,8 @@ internal object ObservabilityIndex {
                     throw exception
                 }
             }
-        }
-        if (!this.mappingsUpdated) {
+            this.mappingsUpdated = true
+        } else if (!this.mappingsUpdated) {
             updateMappings()
         }
     }


### PR DESCRIPTION
### Description
- In Services tab, clicking on Traces column of a specific service redirects you to the Traces & Spans tab with a new filter of the service you selected
- Also fixed bug where opening a span detail flyout from a trace detail flyout was not closing the previous flyouts
- Change `updateMappings` to only be called on the first request by creating a new variable `mappingsUpdated` that is initialized to false but is changed to true in the first call of `updateMappings`
- Add multiple visualizations to metrics tab
- Do not scroll to top of page on service map click on the app creation page

### Issues Resolved
Resolves #470 
Fixes #394 
Fixes #403 
Fixes #468 
Fixes #469 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
