### PR TITLE
Revert query pre-processing for parse command

### DIFF
--- a/dashboards-observability/common/utils/query_utils.ts
+++ b/dashboards-observability/common/utils/query_utils.ts
@@ -3,26 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isEmpty } from 'lodash';
-import datemath from '@elastic/datemath';
-import { DATE_PICKER_FORMAT } from '../../common/constants/explorer';
+import datemath from "@elastic/datemath";
+import { isEmpty } from "lodash";
+import { DATE_PICKER_FORMAT } from "../../common/constants/explorer";
 import {
-  PPL_INDEX_REGEX,
   PPL_INDEX_INSERT_POINT_REGEX,
-  PPL_NEWLINE_REGEX
-} from '../../common/constants/shared';
+  PPL_INDEX_REGEX,
+  PPL_NEWLINE_REGEX,
+} from "../../common/constants/shared";
 
-export const getIndexPatternFromRawQuery = (query: string) : string => {
+export const getIndexPatternFromRawQuery = (query: string): string => {
   const matches = query.match(PPL_INDEX_REGEX);
   if (matches) {
     return matches[2];
   }
-  return '';
+  return "";
 };
-
-const commandExists = (query: string, command: string): boolean => {
-  return new RegExp(`\\|\\s*${command}\\b`).test(query);
-}
 
 // insert time filter command and additional commands based on raw query
 export const preprocessQuery = ({
@@ -36,24 +32,23 @@ export const preprocessQuery = ({
   endTime: string;
   timeField?: string;
 }) => {
-
-  let finalQuery = '';
+  let finalQuery = "";
 
   if (isEmpty(rawQuery)) return finalQuery;
-    
+
   // convert to moment
   const start = datemath.parse(startTime)?.format(DATE_PICKER_FORMAT);
   const end = datemath.parse(endTime)?.format(DATE_PICKER_FORMAT);
-  const tokens = rawQuery.replaceAll(PPL_NEWLINE_REGEX, '').match(PPL_INDEX_INSERT_POINT_REGEX);
-  
+  const tokens = rawQuery
+    .replaceAll(PPL_NEWLINE_REGEX, "")
+    .match(PPL_INDEX_INSERT_POINT_REGEX);
+
   if (isEmpty(tokens)) return finalQuery;
-
-  let conditions = `| where ${timeField} >= '${start}' and ${timeField} <= '${end}'`;
-  if (commandExists(rawQuery, 'parse')) {
-    conditions += ` | sort - ${timeField} | head 10000`;
-  }
-
-  finalQuery = `${tokens![1]}=${tokens![2]} ${conditions} ${tokens![3]}`;
+  finalQuery = `${tokens![1]}=${
+    tokens![2]
+  } | where ${timeField} >= '${start}' and ${timeField} <= '${end}'${
+    tokens![3]
+  }`;
 
   return finalQuery;
 };


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
PPL parse will pushdown, so this query processing is not necessary in event explorer

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
