### PR TITLE
updated panels flaky jest tests

### DIFF
--- a/dashboards-observability/public/components/custom_panels/helpers/__tests__/utils.test.tsx
+++ b/dashboards-observability/public/components/custom_panels/helpers/__tests__/utils.test.tsx
@@ -37,9 +37,11 @@ describe('Utils helper functions', () => {
   });
 
   it('validates convertDateTime function', () => {
-    expect(convertDateTime('now')).toBe(moment().format(PPL_DATE_FORMAT));
-    expect(convertDateTime('now-y', true)).toBe(
-      moment().subtract(1, 'years').format(PPL_DATE_FORMAT)
+    expect(convertDateTime('2022-01-30T18:44:40.577Z')).toBe(
+      moment('2022-01-30T18:44:40.577Z').format(PPL_DATE_FORMAT)
+    );
+    expect(convertDateTime('2022-02-25T19:18:33.075Z', true)).toBe(
+      moment('2022-02-25T19:18:33.075Z').format(PPL_DATE_FORMAT)
     );
   });
 
@@ -54,24 +56,44 @@ describe('Utils helper functions', () => {
     const setStart = jest.fn();
     const setEnd = jest.fn();
     const recentlyUsedRanges: DurationRange[] = [];
-    onTimeChange('now-y', 'now', recentlyUsedRanges, setRecentlyUsedRanges, setStart, setEnd);
-    expect(setRecentlyUsedRanges).toHaveBeenCalledWith([{ start: 'now-y', end: 'now' }]);
-    expect(setStart).toHaveBeenCalledWith('now-y');
-    expect(setEnd).toHaveBeenCalledWith('now');
+    onTimeChange(
+      '2022-01-30T18:44:40.577Z',
+      '2022-02-25T19:18:33.075Z',
+      recentlyUsedRanges,
+      setRecentlyUsedRanges,
+      setStart,
+      setEnd
+    );
+    expect(setRecentlyUsedRanges).toHaveBeenCalledWith([
+      { start: '2022-01-30T18:44:40.577Z', end: '2022-02-25T19:18:33.075Z' },
+    ]);
+    expect(setStart).toHaveBeenCalledWith('2022-01-30T18:44:40.577Z');
+    expect(setEnd).toHaveBeenCalledWith('2022-02-25T19:18:33.075Z');
   });
 
   it('validates isDateValid function', () => {
     const setToast = jest.fn();
-    expect(isDateValid(convertDateTime('now-y'), convertDateTime('now', false), setToast)).toBe(
-      true
-    );
-    expect(isDateValid(convertDateTime('now'), convertDateTime('now', false), setToast)).toBe(true);
-    expect(isDateValid(convertDateTime('now'), convertDateTime('now-15m', false), setToast)).toBe(
-      false
-    );
-    expect(isDateValid(convertDateTime('now'), convertDateTime('now-1d', false), setToast)).toBe(
-      false
-    );
+    expect(
+      isDateValid(
+        convertDateTime('2022-01-30T18:44:40.577Z'),
+        convertDateTime('2022-02-25T19:18:33.075Z', false),
+        setToast
+      )
+    ).toBe(true);
+    expect(
+      isDateValid(
+        convertDateTime('2022-01-30T18:44:40.577Z'),
+        convertDateTime('2022-01-30T18:44:40.577Z', false),
+        setToast
+      )
+    ).toBe(true);
+    expect(
+      isDateValid(
+        convertDateTime('2022-02-25T19:18:33.075Z'),
+        convertDateTime('2022-01-30T18:44:40.577Z', false),
+        setToast
+      )
+    ).toBe(false);
   });
 
   it('validates isPPLFilterValid function', () => {


### PR DESCRIPTION
Signed-off-by: Shenoy Pratik <sgguruda@amazon.com>

### Description
Panels jest fail at times. The main reason being time-check tests, where ('now') is used to get the current moment time and then perform tests over it. These tests fail is there in minor gap in function exec and test run. 

Solution:
Removed usage of relative times like 'now' or 'now-y' and  added absolute times. 

```
Summary of all failing tests
FAIL public/components/custom_panels/helpers/__tests__/utils.test.tsx
  ● Utils helper functions › validates convertDateTime function

    expect(received).toBe(expected) // Object.is equality

    Expected: "2021-02-24 07:40:30"
    Received: "2021-02-24 07:40:29"

      39 |   it('validates convertDateTime function', () => {
      40 |     expect(convertDateTime('now')).toBe(moment().format(PPL_DATE_FORMAT));
    > 41 |     expect(convertDateTime('now-y', true)).toBe(
         |                                            ^
      42 |       moment().subtract(1, 'years').format(PPL_DATE_FORMAT)
      43 |     );
      44 |   });

      at Object.it (public/components/custom_panels/helpers/__tests__/utils.test.tsx:41:44)
```

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
