### PR TITLE
Fix lower margin of autocomplete being cut off

### DIFF
--- a/dashboards-observability/public/components/application_analytics/__tests__/__snapshots__/create.test.tsx.snap
+++ b/dashboards-observability/public/components/application_analytics/__tests__/__snapshots__/create.test.tsx.snap
@@ -241,7 +241,7 @@ Object {
                           >
                             <div
                               class="euiCallOut euiCallOut--primary euiCallOut--small"
-                              style="max-width: 900px;"
+                              id="baseQueryCallout"
                             >
                               <div
                                 class="euiText euiText--extraSmall"
@@ -274,7 +274,6 @@ Object {
                                   aria-describedby="random_html_id-help"
                                   class="euiFlexItem euiFlexItem--flexGrowZero query-area"
                                   id="random_html_id"
-                                  style="min-width: 900px;"
                                 >
                                   <div
                                     aria-expanded="false"
@@ -305,7 +304,7 @@ Object {
                                   </div>
                                   <button
                                     aria-label="pplLinkShowFlyout"
-                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
+                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
                                     title="PPL"
                                   >
                                     <span
@@ -1449,7 +1448,7 @@ Object {
                         >
                           <div
                             class="euiCallOut euiCallOut--primary euiCallOut--small"
-                            style="max-width: 900px;"
+                            id="baseQueryCallout"
                           >
                             <div
                               class="euiText euiText--extraSmall"
@@ -1482,7 +1481,6 @@ Object {
                                 aria-describedby="random_html_id-help"
                                 class="euiFlexItem euiFlexItem--flexGrowZero query-area"
                                 id="random_html_id"
-                                style="min-width: 900px;"
                               >
                                 <div
                                   aria-expanded="false"
@@ -1513,7 +1511,7 @@ Object {
                                 </div>
                                 <button
                                   aria-label="pplLinkShowFlyout"
-                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
+                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
                                   title="PPL"
                                 >
                                   <span
@@ -2596,7 +2594,7 @@ Object {
                           >
                             <div
                               class="euiCallOut euiCallOut--primary euiCallOut--small"
-                              style="max-width: 900px;"
+                              id="baseQueryCallout"
                             >
                               <div
                                 class="euiText euiText--extraSmall"
@@ -2629,7 +2627,6 @@ Object {
                                   aria-describedby="random_html_id-help"
                                   class="euiFlexItem euiFlexItem--flexGrowZero query-area"
                                   id="random_html_id"
-                                  style="min-width: 900px;"
                                 >
                                   <div
                                     aria-expanded="false"
@@ -2658,7 +2655,7 @@ Object {
                                   </div>
                                   <button
                                     aria-label="pplLinkShowFlyout"
-                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
+                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
                                     title="PPL"
                                   >
                                     <span
@@ -3715,7 +3712,7 @@ Object {
                         >
                           <div
                             class="euiCallOut euiCallOut--primary euiCallOut--small"
-                            style="max-width: 900px;"
+                            id="baseQueryCallout"
                           >
                             <div
                               class="euiText euiText--extraSmall"
@@ -3748,7 +3745,6 @@ Object {
                                 aria-describedby="random_html_id-help"
                                 class="euiFlexItem euiFlexItem--flexGrowZero query-area"
                                 id="random_html_id"
-                                style="min-width: 900px;"
                               >
                                 <div
                                   aria-expanded="false"
@@ -3777,7 +3773,7 @@ Object {
                                 </div>
                                 <button
                                   aria-label="pplLinkShowFlyout"
-                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
+                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
                                   title="PPL"
                                 >
                                   <span
@@ -4893,7 +4889,7 @@ Object {
                           >
                             <div
                               class="euiCallOut euiCallOut--primary euiCallOut--small"
-                              style="max-width: 900px;"
+                              id="baseQueryCallout"
                             >
                               <div
                                 class="euiText euiText--extraSmall"
@@ -4926,7 +4922,6 @@ Object {
                                   aria-describedby="random_html_id-help"
                                   class="euiFlexItem euiFlexItem--flexGrowZero query-area"
                                   id="random_html_id"
-                                  style="min-width: 900px;"
                                 >
                                   <div
                                     aria-expanded="false"
@@ -4955,7 +4950,7 @@ Object {
                                   </div>
                                   <button
                                     aria-label="pplLinkShowFlyout"
-                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
+                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
                                     title="PPL"
                                   >
                                     <span
@@ -6012,7 +6007,7 @@ Object {
                         >
                           <div
                             class="euiCallOut euiCallOut--primary euiCallOut--small"
-                            style="max-width: 900px;"
+                            id="baseQueryCallout"
                           >
                             <div
                               class="euiText euiText--extraSmall"
@@ -6045,7 +6040,6 @@ Object {
                                 aria-describedby="random_html_id-help"
                                 class="euiFlexItem euiFlexItem--flexGrowZero query-area"
                                 id="random_html_id"
-                                style="min-width: 900px;"
                               >
                                 <div
                                   aria-expanded="false"
@@ -6074,7 +6068,7 @@ Object {
                                 </div>
                                 <button
                                   aria-label="pplLinkShowFlyout"
-                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
+                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
                                   title="PPL"
                                 >
                                   <span
@@ -7183,7 +7177,7 @@ Object {
                           >
                             <div
                               class="euiCallOut euiCallOut--primary euiCallOut--small"
-                              style="max-width: 900px;"
+                              id="baseQueryCallout"
                             >
                               <div
                                 class="euiText euiText--extraSmall"
@@ -7216,7 +7210,6 @@ Object {
                                   aria-describedby="random_html_id-help"
                                   class="euiFlexItem euiFlexItem--flexGrowZero query-area"
                                   id="random_html_id"
-                                  style="min-width: 900px;"
                                 >
                                   <div
                                     aria-expanded="false"
@@ -7245,7 +7238,7 @@ Object {
                                   </div>
                                   <button
                                     aria-label="pplLinkShowFlyout"
-                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
+                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
                                     title="PPL"
                                   >
                                     <span
@@ -8240,7 +8233,7 @@ Object {
                         >
                           <div
                             class="euiCallOut euiCallOut--primary euiCallOut--small"
-                            style="max-width: 900px;"
+                            id="baseQueryCallout"
                           >
                             <div
                               class="euiText euiText--extraSmall"
@@ -8273,7 +8266,6 @@ Object {
                                 aria-describedby="random_html_id-help"
                                 class="euiFlexItem euiFlexItem--flexGrowZero query-area"
                                 id="random_html_id"
-                                style="min-width: 900px;"
                               >
                                 <div
                                   aria-expanded="false"
@@ -8302,7 +8294,7 @@ Object {
                                 </div>
                                 <button
                                   aria-label="pplLinkShowFlyout"
-                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
+                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
                                   title="PPL"
                                 >
                                   <span
@@ -9359,7 +9351,7 @@ Object {
                           >
                             <div
                               class="euiCallOut euiCallOut--primary euiCallOut--small"
-                              style="max-width: 900px;"
+                              id="baseQueryCallout"
                             >
                               <div
                                 class="euiText euiText--extraSmall"
@@ -9392,7 +9384,6 @@ Object {
                                   aria-describedby="random_html_id-help"
                                   class="euiFlexItem euiFlexItem--flexGrowZero query-area"
                                   id="random_html_id"
-                                  style="min-width: 900px;"
                                 >
                                   <div
                                     aria-expanded="false"
@@ -9423,7 +9414,7 @@ Object {
                                   </div>
                                   <button
                                     aria-label="pplLinkShowFlyout"
-                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
+                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
                                     title="PPL"
                                   >
                                     <span
@@ -10447,7 +10438,7 @@ Object {
                         >
                           <div
                             class="euiCallOut euiCallOut--primary euiCallOut--small"
-                            style="max-width: 900px;"
+                            id="baseQueryCallout"
                           >
                             <div
                               class="euiText euiText--extraSmall"
@@ -10480,7 +10471,6 @@ Object {
                                 aria-describedby="random_html_id-help"
                                 class="euiFlexItem euiFlexItem--flexGrowZero query-area"
                                 id="random_html_id"
-                                style="min-width: 900px;"
                               >
                                 <div
                                   aria-expanded="false"
@@ -10511,7 +10501,7 @@ Object {
                                 </div>
                                 <button
                                   aria-label="pplLinkShowFlyout"
-                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
+                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
                                   title="PPL"
                                 >
                                   <span
@@ -11594,7 +11584,7 @@ Object {
                           >
                             <div
                               class="euiCallOut euiCallOut--primary euiCallOut--small"
-                              style="max-width: 900px;"
+                              id="baseQueryCallout"
                             >
                               <div
                                 class="euiText euiText--extraSmall"
@@ -11627,7 +11617,6 @@ Object {
                                   aria-describedby="random_html_id-help"
                                   class="euiFlexItem euiFlexItem--flexGrowZero query-area"
                                   id="random_html_id"
-                                  style="min-width: 900px;"
                                 >
                                   <div
                                     aria-expanded="false"
@@ -11656,7 +11645,7 @@ Object {
                                   </div>
                                   <button
                                     aria-label="pplLinkShowFlyout"
-                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
+                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
                                     title="PPL"
                                   >
                                     <span
@@ -12713,7 +12702,7 @@ Object {
                         >
                           <div
                             class="euiCallOut euiCallOut--primary euiCallOut--small"
-                            style="max-width: 900px;"
+                            id="baseQueryCallout"
                           >
                             <div
                               class="euiText euiText--extraSmall"
@@ -12746,7 +12735,6 @@ Object {
                                 aria-describedby="random_html_id-help"
                                 class="euiFlexItem euiFlexItem--flexGrowZero query-area"
                                 id="random_html_id"
-                                style="min-width: 900px;"
                               >
                                 <div
                                   aria-expanded="false"
@@ -12775,7 +12763,7 @@ Object {
                                 </div>
                                 <button
                                   aria-label="pplLinkShowFlyout"
-                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
+                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
                                   title="PPL"
                                 >
                                   <span
@@ -13891,7 +13879,7 @@ Object {
                           >
                             <div
                               class="euiCallOut euiCallOut--primary euiCallOut--small"
-                              style="max-width: 900px;"
+                              id="baseQueryCallout"
                             >
                               <div
                                 class="euiText euiText--extraSmall"
@@ -13924,7 +13912,6 @@ Object {
                                   aria-describedby="random_html_id-help"
                                   class="euiFlexItem euiFlexItem--flexGrowZero query-area"
                                   id="random_html_id"
-                                  style="min-width: 900px;"
                                 >
                                   <div
                                     aria-expanded="false"
@@ -13953,7 +13940,7 @@ Object {
                                   </div>
                                   <button
                                     aria-label="pplLinkShowFlyout"
-                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
+                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
                                     title="PPL"
                                   >
                                     <span
@@ -15010,7 +14997,7 @@ Object {
                         >
                           <div
                             class="euiCallOut euiCallOut--primary euiCallOut--small"
-                            style="max-width: 900px;"
+                            id="baseQueryCallout"
                           >
                             <div
                               class="euiText euiText--extraSmall"
@@ -15043,7 +15030,6 @@ Object {
                                 aria-describedby="random_html_id-help"
                                 class="euiFlexItem euiFlexItem--flexGrowZero query-area"
                                 id="random_html_id"
-                                style="min-width: 900px;"
                               >
                                 <div
                                   aria-expanded="false"
@@ -15072,7 +15058,7 @@ Object {
                                 </div>
                                 <button
                                   aria-label="pplLinkShowFlyout"
-                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
+                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
                                   title="PPL"
                                 >
                                   <span
@@ -16190,7 +16176,7 @@ Object {
                           >
                             <div
                               class="euiCallOut euiCallOut--primary euiCallOut--small"
-                              style="max-width: 900px;"
+                              id="baseQueryCallout"
                             >
                               <div
                                 class="euiText euiText--extraSmall"
@@ -16223,7 +16209,6 @@ Object {
                                   aria-describedby="random_html_id-help"
                                   class="euiFlexItem euiFlexItem--flexGrowZero query-area"
                                   id="random_html_id"
-                                  style="min-width: 900px;"
                                 >
                                   <div
                                     aria-expanded="false"
@@ -16254,7 +16239,7 @@ Object {
                                   </div>
                                   <button
                                     aria-label="pplLinkShowFlyout"
-                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
+                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
                                     title="PPL"
                                   >
                                     <span
@@ -17394,7 +17379,7 @@ Object {
                         >
                           <div
                             class="euiCallOut euiCallOut--primary euiCallOut--small"
-                            style="max-width: 900px;"
+                            id="baseQueryCallout"
                           >
                             <div
                               class="euiText euiText--extraSmall"
@@ -17427,7 +17412,6 @@ Object {
                                 aria-describedby="random_html_id-help"
                                 class="euiFlexItem euiFlexItem--flexGrowZero query-area"
                                 id="random_html_id"
-                                style="min-width: 900px;"
                               >
                                 <div
                                   aria-expanded="false"
@@ -17458,7 +17442,7 @@ Object {
                                 </div>
                                 <button
                                   aria-label="pplLinkShowFlyout"
-                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
+                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
                                   title="PPL"
                                 >
                                   <span

--- a/dashboards-observability/public/components/application_analytics/__tests__/__snapshots__/create.test.tsx.snap
+++ b/dashboards-observability/public/components/application_analytics/__tests__/__snapshots__/create.test.tsx.snap
@@ -304,7 +304,7 @@ Object {
                                   </div>
                                   <button
                                     aria-label="pplLinkShowFlyout"
-                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
+                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
                                     title="PPL"
                                   >
                                     <span
@@ -1511,7 +1511,7 @@ Object {
                                 </div>
                                 <button
                                   aria-label="pplLinkShowFlyout"
-                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
+                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
                                   title="PPL"
                                 >
                                   <span
@@ -2655,7 +2655,7 @@ Object {
                                   </div>
                                   <button
                                     aria-label="pplLinkShowFlyout"
-                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
+                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
                                     title="PPL"
                                   >
                                     <span
@@ -3773,7 +3773,7 @@ Object {
                                 </div>
                                 <button
                                   aria-label="pplLinkShowFlyout"
-                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
+                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
                                   title="PPL"
                                 >
                                   <span
@@ -4950,7 +4950,7 @@ Object {
                                   </div>
                                   <button
                                     aria-label="pplLinkShowFlyout"
-                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
+                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
                                     title="PPL"
                                   >
                                     <span
@@ -6068,7 +6068,7 @@ Object {
                                 </div>
                                 <button
                                   aria-label="pplLinkShowFlyout"
-                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
+                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
                                   title="PPL"
                                 >
                                   <span
@@ -7238,7 +7238,7 @@ Object {
                                   </div>
                                   <button
                                     aria-label="pplLinkShowFlyout"
-                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
+                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
                                     title="PPL"
                                   >
                                     <span
@@ -8294,7 +8294,7 @@ Object {
                                 </div>
                                 <button
                                   aria-label="pplLinkShowFlyout"
-                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
+                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
                                   title="PPL"
                                 >
                                   <span
@@ -9414,7 +9414,7 @@ Object {
                                   </div>
                                   <button
                                     aria-label="pplLinkShowFlyout"
-                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
+                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
                                     title="PPL"
                                   >
                                     <span
@@ -10501,7 +10501,7 @@ Object {
                                 </div>
                                 <button
                                   aria-label="pplLinkShowFlyout"
-                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
+                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
                                   title="PPL"
                                 >
                                   <span
@@ -11645,7 +11645,7 @@ Object {
                                   </div>
                                   <button
                                     aria-label="pplLinkShowFlyout"
-                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
+                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
                                     title="PPL"
                                   >
                                     <span
@@ -12763,7 +12763,7 @@ Object {
                                 </div>
                                 <button
                                   aria-label="pplLinkShowFlyout"
-                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
+                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
                                   title="PPL"
                                 >
                                   <span
@@ -13940,7 +13940,7 @@ Object {
                                   </div>
                                   <button
                                     aria-label="pplLinkShowFlyout"
-                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
+                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
                                     title="PPL"
                                   >
                                     <span
@@ -15058,7 +15058,7 @@ Object {
                                 </div>
                                 <button
                                   aria-label="pplLinkShowFlyout"
-                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
+                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
                                   title="PPL"
                                 >
                                   <span
@@ -16239,7 +16239,7 @@ Object {
                                   </div>
                                   <button
                                     aria-label="pplLinkShowFlyout"
-                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
+                                    class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
                                     title="PPL"
                                   >
                                     <span
@@ -17442,7 +17442,7 @@ Object {
                                 </div>
                                 <button
                                   aria-label="pplLinkShowFlyout"
-                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
+                                  class="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
                                   title="PPL"
                                 >
                                   <span

--- a/dashboards-observability/public/components/application_analytics/__tests__/__snapshots__/log_config.test.tsx.snap
+++ b/dashboards-observability/public/components/application_analytics/__tests__/__snapshots__/log_config.test.tsx.snap
@@ -240,20 +240,12 @@ exports[`Log Config component renders empty log config 1`] = `
                       >
                         <EuiCallOut
                           iconType="iInCircle"
+                          id="baseQueryCallout"
                           size="s"
-                          style={
-                            Object {
-                              "maxWidth": "900px",
-                            }
-                          }
                         >
                           <div
                             className="euiCallOut euiCallOut--primary euiCallOut--small"
-                            style={
-                              Object {
-                                "maxWidth": "900px",
-                              }
-                            }
+                            id="baseQueryCallout"
                           >
                             <EuiText
                               size="xs"
@@ -314,11 +306,6 @@ exports[`Log Config component renders empty log config 1`] = `
                                 key="query-bar"
                                 onBlur={[Function]}
                                 onFocus={[Function]}
-                                style={
-                                  Object {
-                                    "minWidth": "900px",
-                                  }
-                                }
                               >
                                 <div
                                   aria-describedby="random_html_id-help"
@@ -326,11 +313,6 @@ exports[`Log Config component renders empty log config 1`] = `
                                   id="random_html_id"
                                   onBlur={[Function]}
                                   onFocus={[Function]}
-                                  style={
-                                    Object {
-                                      "minWidth": "900px",
-                                    }
-                                  }
                                 >
                                   <Autocomplete
                                     baseQuery=""
@@ -412,7 +394,7 @@ exports[`Log Config component renders empty log config 1`] = `
                                     </div>
                                   </Autocomplete>
                                   <EuiBadge
-                                    className="ppl-link ppl-link-light"
+                                    className="ppl-create-link ppl-create-link-light"
                                     color="hollow"
                                     onClick={[Function]}
                                     onClickAriaLabel="pplLinkShowFlyout"
@@ -420,7 +402,7 @@ exports[`Log Config component renders empty log config 1`] = `
                                     <EuiInnerText>
                                       <button
                                         aria-label="pplLinkShowFlyout"
-                                        className="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
+                                        className="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
                                         disabled={false}
                                         onClick={[Function]}
                                         title="PPL"
@@ -712,20 +694,12 @@ exports[`Log Config component renders with query 1`] = `
                       >
                         <EuiCallOut
                           iconType="iInCircle"
+                          id="baseQueryCallout"
                           size="s"
-                          style={
-                            Object {
-                              "maxWidth": "900px",
-                            }
-                          }
                         >
                           <div
                             className="euiCallOut euiCallOut--primary euiCallOut--small"
-                            style={
-                              Object {
-                                "maxWidth": "900px",
-                              }
-                            }
+                            id="baseQueryCallout"
                           >
                             <EuiText
                               size="xs"
@@ -786,11 +760,6 @@ exports[`Log Config component renders with query 1`] = `
                                 key="query-bar"
                                 onBlur={[Function]}
                                 onFocus={[Function]}
-                                style={
-                                  Object {
-                                    "minWidth": "900px",
-                                  }
-                                }
                               >
                                 <div
                                   aria-describedby="random_html_id-help"
@@ -798,11 +767,6 @@ exports[`Log Config component renders with query 1`] = `
                                   id="random_html_id"
                                   onBlur={[Function]}
                                   onFocus={[Function]}
-                                  style={
-                                    Object {
-                                      "minWidth": "900px",
-                                    }
-                                  }
                                 >
                                   <Autocomplete
                                     baseQuery=""
@@ -884,7 +848,7 @@ exports[`Log Config component renders with query 1`] = `
                                     </div>
                                   </Autocomplete>
                                   <EuiBadge
-                                    className="ppl-link ppl-link-light"
+                                    className="ppl-create-link ppl-create-link-light"
                                     color="hollow"
                                     onClick={[Function]}
                                     onClickAriaLabel="pplLinkShowFlyout"
@@ -892,7 +856,7 @@ exports[`Log Config component renders with query 1`] = `
                                     <EuiInnerText>
                                       <button
                                         aria-label="pplLinkShowFlyout"
-                                        className="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
+                                        className="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
                                         disabled={false}
                                         onClick={[Function]}
                                         title="PPL"

--- a/dashboards-observability/public/components/application_analytics/__tests__/__snapshots__/log_config.test.tsx.snap
+++ b/dashboards-observability/public/components/application_analytics/__tests__/__snapshots__/log_config.test.tsx.snap
@@ -394,7 +394,7 @@ exports[`Log Config component renders empty log config 1`] = `
                                     </div>
                                   </Autocomplete>
                                   <EuiBadge
-                                    className="ppl-create-link ppl-create-link-light"
+                                    className="ppl-link ppl-link-light"
                                     color="hollow"
                                     onClick={[Function]}
                                     onClickAriaLabel="pplLinkShowFlyout"
@@ -402,7 +402,7 @@ exports[`Log Config component renders empty log config 1`] = `
                                     <EuiInnerText>
                                       <button
                                         aria-label="pplLinkShowFlyout"
-                                        className="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
+                                        className="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
                                         disabled={false}
                                         onClick={[Function]}
                                         title="PPL"
@@ -848,7 +848,7 @@ exports[`Log Config component renders with query 1`] = `
                                     </div>
                                   </Autocomplete>
                                   <EuiBadge
-                                    className="ppl-create-link ppl-create-link-light"
+                                    className="ppl-link ppl-link-light"
                                     color="hollow"
                                     onClick={[Function]}
                                     onClickAriaLabel="pplLinkShowFlyout"
@@ -856,7 +856,7 @@ exports[`Log Config component renders with query 1`] = `
                                     <EuiInnerText>
                                       <button
                                         aria-label="pplLinkShowFlyout"
-                                        className="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-create-link ppl-create-link-light"
+                                        className="euiBadge euiBadge-isClickable euiBadge--hollow euiBadge--iconLeft ppl-link ppl-link-light"
                                         disabled={false}
                                         onClick={[Function]}
                                         title="PPL"

--- a/dashboards-observability/public/components/application_analytics/app_analytics.scss
+++ b/dashboards-observability/public/components/application_analytics/app_analytics.scss
@@ -3,21 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- .ppl-create-link {
-  border: unset;
-  position: absolute;
-  top: 103px;
-  right: 140px;
-  background-color: transparent;
-}
-.ppl-create-link-light {
-  color: #006BB4;
-}
-
-.ppl-create-link-dark {
-  color: #1BA9F5;
-}
-
 .query-area {
   width: 900px;
 }
@@ -26,6 +11,10 @@
   overflow: visible;
   position: relative;
   z-index: 10;
+  .ppl-link {
+    top: 103px;
+    right: 140px;
+  }
 }
 
 #baseQueryCallout {

--- a/dashboards-observability/public/components/application_analytics/app_analytics.scss
+++ b/dashboards-observability/public/components/application_analytics/app_analytics.scss
@@ -3,17 +3,31 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- .ppl-link {
+ .ppl-create-link {
   border: unset;
   position: absolute;
   top: 103px;
   right: 140px;
   background-color: transparent;
 }
-.ppl-link-light {
+.ppl-create-link-light {
   color: #006BB4;
 }
 
-.ppl-link-dark {
+.ppl-create-link-dark {
   color: #1BA9F5;
+}
+
+.query-area {
+  width: 900px;
+}
+
+#logSource {
+  overflow: visible;
+  position: relative;
+  z-index: 10;
+}
+
+#baseQueryCallout {
+  max-width: 900px;
 }

--- a/dashboards-observability/public/components/application_analytics/components/config_components/log_config.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/config_components/log_config.tsx
@@ -134,10 +134,8 @@ export const LogConfig = (props: LogConfigProps) => {
                   tabId={'application-analytics-tab'}
                 />
                 <EuiBadge
-                  className={`ppl-create-link ${
-                    uiSettingsService.get('theme:darkMode')
-                      ? 'ppl-create-link-dark'
-                      : 'ppl-create-link-light'
+                  className={`ppl-link ${
+                    uiSettingsService.get('theme:darkMode') ? 'ppl-link-dark' : 'ppl-link-light'
                   }`}
                   color="hollow"
                   onClick={() => showFlyout()}

--- a/dashboards-observability/public/components/application_analytics/components/config_components/log_config.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/config_components/log_config.tsx
@@ -110,7 +110,7 @@ export const LogConfig = (props: LogConfigProps) => {
       >
         <EuiFlexGroup direction="column" gutterSize="s">
           <EuiFlexItem>
-            <EuiCallOut iconType={'iInCircle'} size="s" style={{ maxWidth: '900px' }}>
+            <EuiCallOut id="baseQueryCallout" iconType={'iInCircle'} size="s">
               You can&apos;t change the base query after the application is created.
             </EuiCallOut>
           </EuiFlexItem>
@@ -119,12 +119,7 @@ export const LogConfig = (props: LogConfigProps) => {
               label="Base Query"
               helpText="The default logs view in the application will be filtered by this query."
             >
-              <EuiFlexItem
-                grow={false}
-                key="query-bar"
-                className="query-area"
-                style={{ minWidth: '900px' }}
-              >
+              <EuiFlexItem grow={false} key="query-bar" className="query-area">
                 <Autocomplete
                   key={'autocomplete-bar'}
                   query={query}
@@ -139,8 +134,10 @@ export const LogConfig = (props: LogConfigProps) => {
                   tabId={'application-analytics-tab'}
                 />
                 <EuiBadge
-                  className={`ppl-link ${
-                    uiSettingsService.get('theme:darkMode') ? 'ppl-link-dark' : 'ppl-link-light'
+                  className={`ppl-create-link ${
+                    uiSettingsService.get('theme:darkMode')
+                      ? 'ppl-create-link-dark'
+                      : 'ppl-create-link-light'
                   }`}
                   color="hollow"
                   onClick={() => showFlyout()}

--- a/dashboards-observability/public/components/common/search/autocomplete.tsx
+++ b/dashboards-observability/public/components/common/search/autocomplete.tsx
@@ -143,12 +143,9 @@ export const Autocomplete = (props: AutocompleteProps) => {
             return (
               <div
                 key={`scrollable-${index}`}
-                className="aa-PanelLayout aa-Panel--scrollable"
-                style={
-                  uiSettingsService.get('theme:darkMode')
-                    ? { backgroundColor: '#1D1E24', border: '2px groove #383444' }
-                    : {}
-                }
+                className={`aa-PanelLayout aa-Panel--scrollable ${
+                  uiSettingsService.get('theme:darkMode') ? 'aa-Panel--scrollable-dark' : ''
+                }`}
               >
                 <div key={`source-${index}`} className="aa-Source">
                   {items.length > 0 && (
@@ -158,14 +155,13 @@ export const Autocomplete = (props: AutocompleteProps) => {
                         return (
                           <li
                             key={item.__autocomplete_id}
-                            className="aa-Item"
+                            className={`aa-Item ${
+                              uiSettingsService.get('theme:darkMode') ? 'aa-Item-dark' : ''
+                            }`}
                             {...autocomplete.getItemProps({
                               item,
                               source,
                             })}
-                            style={
-                              uiSettingsService.get('theme:darkMode') ? { color: '#DFE5EF' } : {}
-                            }
                           >
                             <div className="aa-ItemWrapper">
                               <div className="aa-ItemContent">

--- a/dashboards-observability/public/components/common/search/search.scss
+++ b/dashboards-observability/public/components/common/search/search.scss
@@ -20,6 +20,11 @@
   font-weight: bold;
 }
 
+#servicesEntities {
+  position: relative;
+  z-index: 0;
+}
+
 #autocomplete-textarea {
   width: 100%;
   outline: none;
@@ -30,9 +35,19 @@
   font-size: 16px;
   padding-right: 40px;
 }
+
 .aa-Panel {
   width: 100%;
   z-index: 2500;
+}
+
+.aa-Panel--scrollable-dark {
+  background-color: #1D1E24;
+  border: 2px groove #383444;
+}
+
+.aa-Item-dark {
+  color: #DFE5EF;
 }
 
 .event-date-picker {


### PR DESCRIPTION
Signed-off-by: Eugene Lee <eugenesk@amazon.com>

### Description
Previously, the suggestions were being hidden underneath other components.
Changed the overflow to be visible.

### Issues Resolved
Fixes #484 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
