### PR TITLE
Fix empty userConfigs stringify

### DIFF
--- a/dashboards-observability/opensearch_dashboards.json
+++ b/dashboards-observability/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "observabilityDashboards",
   "version": "1.3.0.0",
-  "opensearchDashboardsVersion": "1.2.0",
+  "opensearchDashboardsVersion": "1.3.0",
   "server": true,
   "ui": true,
   "requiredPlugins": [

--- a/dashboards-observability/opensearch_dashboards.json
+++ b/dashboards-observability/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "observabilityDashboards",
   "version": "1.3.0.0",
-  "opensearchDashboardsVersion": "1.3.0",
+  "opensearchDashboardsVersion": "1.2.0",
   "server": true,
   "ui": true,
   "requiredPlugins": [

--- a/dashboards-observability/public/components/explorer/explorer.tsx
+++ b/dashboards-observability/public/components/explorer/explorer.tsx
@@ -976,7 +976,9 @@ export const Explorer = ({
             name: selectedPanelNameRef.current,
             timestamp: currQuery![SELECTED_TIMESTAMP],
             applicationId: appId,
-            userConfigs: JSON.stringify(userVizConfigs[curVisId]),
+            userConfigs: userVizConfigs[curVisId]
+              ? JSON.stringify(userVizConfigs[curVisId])
+              : JSON.stringify({}),
             description: vizDescription,
           })
           .then((res: any) => {

--- a/dashboards-observability/public/components/explorer/explorer.tsx
+++ b/dashboards-observability/public/components/explorer/explorer.tsx
@@ -944,7 +944,9 @@ export const Explorer = ({
             timestamp: currQuery![SELECTED_TIMESTAMP],
             objectId: currQuery![SAVED_OBJECT_ID],
             type: curVisId,
-            userConfigs: JSON.stringify(userVizConfigs[curVisId]),
+            userConfigs: userVizConfigs.hasOwnProperty(curVisId)
+              ? JSON.stringify(userVizConfigs[curVisId])
+              : JSON.stringify({}),
             description: vizDescription,
           })
           .then((res: any) => {
@@ -976,7 +978,7 @@ export const Explorer = ({
             name: selectedPanelNameRef.current,
             timestamp: currQuery![SELECTED_TIMESTAMP],
             applicationId: appId,
-            userConfigs: userVizConfigs[curVisId]
+            userConfigs: userVizConfigs.hasOwnProperty(curVisId)
               ? JSON.stringify(userVizConfigs[curVisId])
               : JSON.stringify({}),
             description: vizDescription,


### PR DESCRIPTION
Signed-off-by: Eugene Lee <eugenesk@amazon.com>

### Description
Allows you to save visualizations that have no userConfigs

### Issues Resolved
[[Link to Bug Bash Issue]](https://quip-amazon.com/edO8AFy8qQ38/WIP-OpenSearch-Observability-13-Release-Test-Plan#temp:s:temp:C:CdN090c2ac00916476481de094e9;temp:C:CdN457369b33ddd4b458150a98fe)

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
