### PR TITLE
fix issue of clicking query caused crash

### DIFF
--- a/dashboards-observability/public/components/explorer/explorer.tsx
+++ b/dashboards-observability/public/components/explorer/explorer.tsx
@@ -118,7 +118,7 @@ export const Explorer = ({
   const explorerFields = useSelector(selectFields)[tabId];
   const countDistribution = useSelector(selectCountDistribution)[tabId];
   const explorerVisualizations = useSelector(selectExplorerVisualization)[tabId];
-  const userVizConfigs = useSelector(selectVisualizationConfig)[tabId];
+  const userVizConfigs = useSelector(selectVisualizationConfig)[tabId] || {};
 
   const [selectedContentTabId, setSelectedContentTab] = useState(TAB_EVENT_ID);
   const [selectedCustomPanelOptions, setSelectedCustomPanelOptions] = useState([]);
@@ -755,7 +755,7 @@ export const Explorer = ({
       rawVizData: explorerVisualizations,
       query,
       indexFields: explorerFields,
-      userConfigs: userVizConfigs[curVisId],
+      userConfigs: userVizConfigs[curVisId] || {},
       appData: { fromApp: appLogEvents },
     });
   }, [curVisId, explorerVisualizations, explorerFields, query, userVizConfigs]);


### PR DESCRIPTION
Signed-off-by: Eric Wei <menwe@amazon.com>

### Description
- fix for clicking saved query/viz causing page crash

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
