### PR TITLE
Edit visualization in Application Analytics

### DIFF
--- a/dashboards-observability/public/components/application_analytics/components/application.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/application.tsx
@@ -25,6 +25,7 @@ import TimestampUtils from 'public/services/timestamp/timestamp';
 import React, { ReactChild, useEffect, useState } from 'react';
 import { uniqueId } from 'lodash';
 import { useHistory } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 import {
   filtersToDsl,
   PanelTitle,
@@ -60,7 +61,6 @@ import { ServiceDetailFlyout } from './flyout_components/service_detail_flyout';
 import { SpanDetailFlyout } from '../../../../public/components/trace_analytics/components/traces/span_detail_flyout';
 import { TraceDetailFlyout } from './flyout_components/trace_detail_flyout';
 import { fetchAppById, initializeTabData } from '../helpers/utils';
-import { useDispatch } from 'react-redux';
 
 const TAB_OVERVIEW_ID = uniqueId(TAB_OVERVIEW_ID_TXT_PFX);
 const TAB_SERVICE_ID = uniqueId(TAB_SERVICE_ID_TXT_PFX);
@@ -134,6 +134,7 @@ export function Application(props: AppDetailProps) {
   const [spanFlyoutId, setSpanFlyoutId] = useState<string>('');
   const [spanDSL, setSpanDSL] = useState<any>({});
   const [totalSpans, setTotalSpans] = useState<number>(0);
+  const [editVizId, setEditVizId] = useState<string>('');
   const handleContentTabClick = (selectedTab: IQueryTab) => setSelectedTab(selectedTab.id);
   const history = useHistory();
 
@@ -226,6 +227,7 @@ export function Application(props: AppDetailProps) {
         appName={application.name}
         setStartTime={setStartTimeForApp}
         setEndTime={setEndTimeForApp}
+        switchToEditViz={switchToEditViz}
       />
     );
   };
@@ -241,6 +243,7 @@ export function Application(props: AppDetailProps) {
         setStartTime={setStartTimeForApp}
         setEndTime={setEndTimeForApp}
         switchToTrace={switchToTrace}
+        switchToEditViz={switchToEditViz}
       />
     );
   };
@@ -260,6 +263,7 @@ export function Application(props: AppDetailProps) {
           openTraceFlyout={openTraceFlyout}
           setStartTime={setStartTimeForApp}
           setEndTime={setEndTimeForApp}
+          switchToEditViz={switchToEditViz}
         />
         <EuiSpacer size="m" />
         <EuiPanel>
@@ -289,7 +293,7 @@ export function Application(props: AppDetailProps) {
         setToast={setToasts}
         history={history}
         notifications={notifications}
-        savedObjectId={''}
+        savedObjectId={editVizId}
         http={http}
         searchBarConfigs={searchBarConfigs}
         appId={appId}
@@ -325,6 +329,7 @@ export function Application(props: AppDetailProps) {
         setStartTime={setStartTimeForApp}
         setEndTime={setEndTimeForApp}
         switchToEvent={switchToEvent}
+        switchToEditViz={switchToEditViz}
       />
     );
   };
@@ -333,9 +338,23 @@ export function Application(props: AppDetailProps) {
     setSelectedTab(TAB_LOG_ID);
   };
 
+  const switchToEditViz = (savedVizId: string) => {
+    if (savedVizId) {
+      setEditVizId(savedVizId);
+      switchToEvent();
+    } else {
+      setEditVizId('');
+    }
+  };
+
   const getConfig = () => {
     return (
-      <Configuration appId={appId} parentBreadcrumb={parentBreadcrumb} application={application} />
+      <Configuration
+        appId={appId}
+        parentBreadcrumb={parentBreadcrumb}
+        application={application}
+        switchToEditViz={switchToEditViz}
+      />
     );
   };
 

--- a/dashboards-observability/public/components/application_analytics/components/configuration.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/configuration.tsx
@@ -2,6 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+/* eslint-disable react-hooks/exhaustive-deps */
 
 import {
   EuiBreadcrumb,
@@ -22,16 +23,20 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { ApplicationType } from 'common/types/app_analytics';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 interface ConfigProps {
   appId: string;
   application: ApplicationType;
   parentBreadcrumb: EuiBreadcrumb;
+  switchToEditViz: (savedVizId: string) => void;
 }
 
 export const Configuration = (props: ConfigProps) => {
-  const { appId, application, parentBreadcrumb } = props;
+  const { appId, application, parentBreadcrumb, switchToEditViz } = props;
+  useEffect(() => {
+    switchToEditViz('');
+  }, []);
 
   return (
     <div>

--- a/dashboards-observability/public/components/application_analytics/components/create.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/create.tsx
@@ -82,7 +82,7 @@ export const CreateApp = (props: CreateAppProps) => {
         href: '#/application_analytics',
       },
       {
-        text: editMode ? 'Edit' : 'Create',
+        text: editMode ? 'Save' : 'Create',
         href: `#/application_analytics/${editMode ? 'edit' : 'create'}`,
       },
     ]);

--- a/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
+++ b/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
@@ -89,6 +89,7 @@ interface Props {
   setStartTime: any;
   setEndTime: any;
   switchToEvent?: any;
+  switchToEditViz?: any;
 }
 
 export const CustomPanelView = ({
@@ -109,6 +110,7 @@ export const CustomPanelView = ({
   cloneCustomPanel,
   setToast,
   switchToEvent,
+  switchToEditViz,
 }: Props) => {
   const [openPanelName, setOpenPanelName] = useState('');
   const [panelCreatedTime, setPanelCreatedTime] = useState('');
@@ -477,6 +479,13 @@ export const CustomPanelView = ({
     },
   ];
 
+  // Set saved object id to empty when redirect away from events tab
+  useEffect(() => {
+    if (appPanel) {
+      switchToEditViz('');
+    }
+  });
+
   // Fetch the custom panel on Initial Mount
   useEffect(() => {
     fetchCustomPanel();
@@ -626,7 +635,11 @@ export const CustomPanelView = ({
               {appPanel && (
                 <>
                   <EuiFlexItem grow={false}>
-                    <EuiButton iconType="pencil" onClick={() => {}} isDisabled={editDisabled}>
+                    <EuiButton
+                      iconType="pencil"
+                      onClick={() => editPanel('edit')}
+                      isDisabled={editDisabled}
+                    >
                       Edit
                     </EuiButton>
                   </EuiFlexItem>
@@ -661,11 +674,13 @@ export const CustomPanelView = ({
               pplService={pplService}
               startTime={startTime}
               endTime={endTime}
+              fromApp={appPanel}
               onRefresh={onRefresh}
               cloneVisualization={cloneVisualization}
               pplFilterValue={pplFilterValue}
               showFlyout={showFlyout}
               editActionType={editActionType}
+              switchToEditViz={switchToEditViz}
             />
           </EuiPageContentBody>
         </EuiPageBody>

--- a/dashboards-observability/public/components/custom_panels/panel_modules/panel_grid/panel_grid.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/panel_grid/panel_grid.tsx
@@ -48,11 +48,14 @@ type Props = {
   pplService: PPLService;
   startTime: string;
   endTime: string;
+  fromApp?: boolean;
+  switchToEditViz?: any;
   onRefresh: boolean;
   cloneVisualization: (visualzationTitle: string, savedVisualizationId: string) => void;
   pplFilterValue: string;
   showFlyout: (isReplacement?: boolean | undefined, replaceVizId?: string | undefined) => void;
   editActionType: string;
+  setEditVizId?: any;
 };
 
 export const PanelGrid = ({
@@ -65,6 +68,8 @@ export const PanelGrid = ({
   pplService,
   startTime,
   endTime,
+  fromApp = false,
+  switchToEditViz,
   onRefresh,
   cloneVisualization,
   pplFilterValue,
@@ -95,6 +100,8 @@ export const PanelGrid = ({
           fromTime={startTime}
           toTime={endTime}
           onRefresh={onRefresh}
+          fromApp={fromApp}
+          switchToEditViz={switchToEditViz}
           cloneVisualization={cloneVisualization}
           pplFilterValue={pplFilterValue}
           showFlyout={showFlyout}

--- a/dashboards-observability/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
@@ -53,6 +53,8 @@ interface Props {
   onRefresh: boolean;
   pplFilterValue: string;
   usedInNotebooks?: boolean;
+  fromApp?: boolean;
+  switchToEditViz?: any;
   cloneVisualization?: (visualzationTitle: string, savedVisualizationId: string) => void;
   showFlyout?: (isReplacement?: boolean | undefined, replaceVizId?: string | undefined) => void;
   removeVisualization?: (visualizationId: string) => void;
@@ -69,6 +71,8 @@ export const VisualizationContainer = ({
   onRefresh,
   pplFilterValue,
   usedInNotebooks,
+  fromApp,
+  switchToEditViz,
   cloneVisualization,
   showFlyout,
   removeVisualization,
@@ -90,7 +94,11 @@ export const VisualizationContainer = ({
       disabled={disablePopover}
       onClick={() => {
         closeActionsMenu();
-        window.location.assign(`#/event_analytics/explorer/${savedVisualizationId}`);
+        if (fromApp) {
+          switchToEditViz(savedVisualizationId);
+        } else {
+          window.location.assign(`#/event_analytics/explorer/${savedVisualizationId}`);
+        }
       }}
     >
       Edit

--- a/dashboards-observability/public/components/explorer/log_explorer.tsx
+++ b/dashboards-observability/public/components/explorer/log_explorer.tsx
@@ -16,22 +16,13 @@ import {
   TAB_ID_TXT_PFX,
   SAVED_OBJECT_ID,
   NEW_TAB,
-  TAB_CREATED_TYPE,
   REDIRECT_TAB,
-  NEW_SELECTED_QUERY_TAB,
   TAB_EVENT_ID,
   TAB_CHART_ID,
 } from '../../../common/constants/explorer';
-import { selectQueryTabs, addTab, setSelectedQueryTab, removeTab } from './slices/query_tab_slice';
+import { selectQueryTabs, setSelectedQueryTab } from './slices/query_tab_slice';
 import { selectQueries } from './slices/query_slice';
-import { init as initFields, remove as removefields } from './slices/field_slice';
-import { init as initQuery, remove as removeQuery, changeQuery } from './slices/query_slice';
-import {
-  init as initQueryResult,
-  remove as removeQueryResult,
-  selectQueryResult,
-} from './slices/query_result_slice';
-import { init as initVisualizationConfig, reset as resetVisualizationConfig } from './slices/viualization_config_slice';
+import { selectQueryResult } from './slices/query_result_slice';
 import { initializeTabData, removeTabData } from '../application_analytics/helpers/utils';
 
 const searchBarConfigs = {
@@ -139,7 +130,6 @@ export const LogExplorer = ({
     const newTabId = emptyTabId ? emptyTabId : await addNewTab(REDIRECT_TAB);
     return newTabId;
   };
-
 
   useEffect(() => {
     if (!isEmpty(savedObjectId)) {

--- a/dashboards-observability/public/components/trace_analytics/components/dashboard/dashboard.tsx
+++ b/dashboards-observability/public/components/trace_analytics/components/dashboard/dashboard.tsx
@@ -31,11 +31,12 @@ import { DashboardTable } from './dashboard_table';
 interface DashboardProps extends TraceAnalyticsComponentDeps {
   appId?: string;
   appName?: string;
+  switchToEditViz?: any;
   page: 'dashboard' | 'traces' | 'services' | 'app';
 }
 
 export function Dashboard(props: DashboardProps) {
-  const { appId, appName, page, parentBreadcrumb } = props;
+  const { appId, appName, page, parentBreadcrumb, switchToEditViz } = props;
   const [tableItems, setTableItems] = useState([]);
   const [throughputPltItems, setThroughputPltItems] = useState({ items: [], fixedInterval: '1h' });
   const [errorRatePltItems, setErrorRatePltItems] = useState({ items: [], fixedInterval: '1h' });
@@ -80,6 +81,9 @@ export function Dashboard(props: DashboardProps) {
       })),
     ]);
     setRedirect(false);
+    if (appOverview) {
+      switchToEditViz('');
+    }
   }, []);
 
   useEffect(() => {

--- a/dashboards-observability/public/components/trace_analytics/components/services/services.tsx
+++ b/dashboards-observability/public/components/trace_analytics/components/services/services.tsx
@@ -18,11 +18,12 @@ interface ServicesProps extends TraceAnalyticsComponentDeps {
   appName?: string;
   openServiceFlyout?: (serviceName: string) => void;
   switchToTrace?: () => void;
+  switchToEditViz?: any;
   page: 'dashboard' | 'traces' | 'services' | 'app';
 }
 
 export function Services(props: ServicesProps) {
-  const { appId, appName, parentBreadcrumb, page } = props;
+  const { appId, appName, parentBreadcrumb, page, switchToEditViz } = props;
   const [tableItems, setTableItems] = useState([]);
   const [redirect, setRedirect] = useState(true);
   const [loading, setLoading] = useState(false);
@@ -60,6 +61,9 @@ export function Services(props: ServicesProps) {
       })),
     ]);
     setRedirect(false);
+    if (appServices) {
+      switchToEditViz('');
+    }
   }, []);
 
   useEffect(() => {

--- a/dashboards-observability/public/components/trace_analytics/components/traces/traces.tsx
+++ b/dashboards-observability/public/components/trace_analytics/components/traces/traces.tsx
@@ -18,10 +18,11 @@ interface TracesProps extends TraceAnalyticsComponentDeps {
   appName?: string;
   page: 'traces' | 'app';
   openTraceFlyout?: (traceId: string) => void;
+  switchToEditViz?: any;
 }
 
 export function Traces(props: TracesProps) {
-  const { appId, appName, parentBreadcrumb, page, openTraceFlyout } = props;
+  const { appId, appName, parentBreadcrumb, page, openTraceFlyout, switchToEditViz } = props;
   const [tableItems, setTableItems] = useState([]);
   const [redirect, setRedirect] = useState(true);
   const [loading, setLoading] = useState(false);
@@ -59,6 +60,9 @@ export function Traces(props: TracesProps) {
       })),
     ]);
     setRedirect(false);
+    if (appTraces) {
+      switchToEditViz('');
+    }
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
Signed-off-by: Eugene Lee <eugenesk@amazon.com>

### Description
- Create a new state for `editVizId` that is passed into log events to fetch when we want to edit a visualization
- Redirect to the log events tab with the `editVizId` set when Edit is clicked
- If user leaves tab while editing, when they return it will be an empty explorer again

### Issues Resolved
Fixes #487 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
