### PR TITLE
Add ability to choose visualization for availability

### DIFF
--- a/dashboards-observability/common/constants/shared.ts
+++ b/dashboards-observability/common/constants/shared.ts
@@ -33,6 +33,7 @@ export const PPL_DOCUMENTATION_URL =
   'https://opensearch.org/docs/latest/observability-plugin/ppl/commands/';
 export const UI_DATE_FORMAT = 'MM/DD/YYYY hh:mm A';
 export const PPL_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss.SSSSSS';
+export const SPAN_REGEX = /span/;
 export const PPL_SPAN_REGEX = /by\s*span/i;
 export const PPL_STATS_REGEX = /\|\s*stats/i;
 export const PPL_INDEX_INSERT_POINT_REGEX = /(search source|source|index)\s*=\s*([^|\s]+)(.*)/i;

--- a/dashboards-observability/common/types/app_analytics.ts
+++ b/dashboards-observability/common/types/app_analytics.ts
@@ -14,7 +14,7 @@ export interface ApplicationListType {
   composition: string[];
   dateCreated: string;
   dateModified: string;
-  availability: { name: string; color: string };
+  availability: { name: string; color: string; mainVisId: string };
 }
 
 export interface ApplicationType {
@@ -24,4 +24,5 @@ export interface ApplicationType {
   servicesEntities: string[];
   traceGroups: string[];
   panelId: string;
+  availabilityVisId: string;
 }

--- a/dashboards-observability/public/components/application_analytics/components/app_table.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/app_table.tsx
@@ -208,8 +208,8 @@ export function AppTable(props: AppTableProps) {
       name: 'Current Availability',
       sortable: true,
       render: (value, record) => {
-        if (value.name && value.color) {
-          return <EuiBadge color={value.color}>{value.name}</EuiBadge>;
+        if (value.name) {
+          return <EuiBadge color={value.color || 'default'}>{value.name}</EuiBadge>;
         } else {
           return <EuiText>Undefined</EuiText>;
         }

--- a/dashboards-observability/public/components/application_analytics/components/application.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/application.tsx
@@ -12,6 +12,7 @@ import {
   EuiPageHeader,
   EuiPageHeaderSection,
   EuiPanel,
+  EuiSelectOption,
   EuiSpacer,
   EuiTabbedContent,
   EuiTabbedContentTab,
@@ -95,6 +96,7 @@ interface AppDetailProps extends AppAnalyticsComponentDeps {
   savedObjects: SavedObjects;
   timestampUtils: TimestampUtils;
   notifications: NotificationsStart;
+  updateApp: (appId: string, updateAppData: Partial<ApplicationType>, type: string) => void;
   setToasts: (title: string, color?: string, text?: ReactChild) => void;
 }
 
@@ -114,6 +116,7 @@ export function Application(props: AppDetailProps) {
     query,
     filters,
     appConfigs,
+    updateApp,
     setAppConfigs,
     setStartTimeWithStorage,
     setEndTimeWithStorage,
@@ -127,6 +130,7 @@ export function Application(props: AppDetailProps) {
     servicesEntities: [],
     traceGroups: [],
     panelId: '',
+    availabilityVisId: '',
   });
   const dispatch = useDispatch();
   const [selectedTabId, setSelectedTab] = useState<string>(TAB_OVERVIEW_ID);
@@ -136,6 +140,7 @@ export function Application(props: AppDetailProps) {
   const [spanDSL, setSpanDSL] = useState<any>({});
   const [totalSpans, setTotalSpans] = useState<number>(0);
   const [editVizId, setEditVizId] = useState<string>('');
+  const [visWithAvailability, setVisWithAvailability] = useState<EuiSelectOption[]>([]);
   const handleContentTabClick = (selectedTab: IQueryTab) => setSelectedTab(selectedTab.id);
   const history = useHistory();
 
@@ -173,6 +178,17 @@ export function Application(props: AppDetailProps) {
           savedVisualizationId: visualizationId,
         }),
       })
+      .then(() => {
+        fetchAppById(
+          http,
+          pplService,
+          appId,
+          setApplication,
+          setAppConfigs,
+          setVisWithAvailability,
+          setToasts
+        );
+      })
       .catch((err) => {
         setToasts(`Error in adding ${visualizationName} visualization to the panel`, 'danger');
         console.error(err);
@@ -180,7 +196,15 @@ export function Application(props: AppDetailProps) {
   };
 
   useEffect(() => {
-    fetchAppById(http, appId, setApplication, setAppConfigs, setToasts);
+    fetchAppById(
+      http,
+      pplService,
+      appId,
+      setApplication,
+      setAppConfigs,
+      setVisWithAvailability,
+      setToasts
+    );
     const tabId = `application-analytics-tab-${appId}`;
     initializeTabData(dispatch, tabId, NEW_TAB);
   }, [appId]);
@@ -372,6 +396,8 @@ export function Application(props: AppDetailProps) {
         parentBreadcrumb={parentBreadcrumb}
         application={application}
         switchToEditViz={switchToEditViz}
+        visWithAvailability={visWithAvailability}
+        updateApp={updateApp}
       />
     );
   };

--- a/dashboards-observability/public/components/application_analytics/components/configuration.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/configuration.tsx
@@ -17,25 +17,42 @@ import {
   EuiPageContentBody,
   EuiPageContentHeader,
   EuiPageContentHeaderSection,
+  EuiSelect,
+  EuiSelectOption,
   EuiSpacer,
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
 import { ApplicationType } from 'common/types/app_analytics';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface ConfigProps {
   appId: string;
   application: ApplicationType;
   parentBreadcrumb: EuiBreadcrumb;
+  visWithAvailability: EuiSelectOption[];
   switchToEditViz: (savedVizId: string) => void;
+  updateApp: (appId: string, updateAppData: Partial<ApplicationType>, type: string) => void;
 }
 
 export const Configuration = (props: ConfigProps) => {
-  const { appId, application, parentBreadcrumb, switchToEditViz } = props;
+  const {
+    appId,
+    application,
+    parentBreadcrumb,
+    visWithAvailability,
+    updateApp,
+    switchToEditViz,
+  } = props;
+  const [availabilityVisId, setAvailabilityVisId] = useState(application.availabilityVisId || '');
   useEffect(() => {
     switchToEditViz('');
   }, []);
+
+  const onAvailabilityVisChange = (event: any) => {
+    setAvailabilityVisId(event.target.value);
+    updateApp(appId, { availabilityVisId: event.target.value }, 'editAvailability');
+  };
 
   return (
     <div>
@@ -85,7 +102,7 @@ export const Configuration = (props: ConfigProps) => {
                   <EuiText size="m">
                     <ul aria-label="List of services and entities">
                       {application.servicesEntities.map((group) => (
-                        <li>{decodeURI(group)}</li>
+                        <li key={`${decodeURI(group)}-item`}>{decodeURI(group)}</li>
                       ))}
                     </ul>
                   </EuiText>
@@ -98,12 +115,22 @@ export const Configuration = (props: ConfigProps) => {
                   <EuiText size="m">
                     <ul aria-label="List of trace groups">
                       {application.traceGroups.map((group) => (
-                        <li>{decodeURI(group)}</li>
+                        <li key={`${decodeURI(group)}-item`}>{decodeURI(group)}</li>
                       ))}
                     </ul>
                   </EuiText>
                 </EuiFlexItem>
-                <EuiFlexItem />
+                <EuiFlexItem>
+                  <EuiText>
+                    <h4>Availability</h4>
+                  </EuiText>
+                  <EuiSpacer size="m" />
+                  <EuiSelect
+                    options={visWithAvailability}
+                    value={availabilityVisId}
+                    onChange={onAvailabilityVisChange}
+                  />
+                </EuiFlexItem>
               </EuiFlexGroup>
             </EuiPageContentBody>
           </EuiPageContent>

--- a/dashboards-observability/public/components/application_analytics/components/create.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/create.tsx
@@ -25,6 +25,7 @@ import {
 } from '@elastic/eui';
 import DSLService from 'public/services/requests/dsl';
 import React, { ReactChild, useEffect, useState } from 'react';
+import PPLService from 'public/services/requests/ppl';
 import { AppAnalyticsComponentDeps } from '../home';
 import { TraceConfig } from './config_components/trace_config';
 import { ServiceConfig } from './config_components/service_config';
@@ -35,9 +36,10 @@ import { fetchAppById } from '../helpers/utils';
 
 interface CreateAppProps extends AppAnalyticsComponentDeps {
   dslService: DSLService;
+  pplService: PPLService;
   setToasts: (title: string, color?: string, text?: ReactChild) => void;
   createApp: (app: ApplicationType) => void;
-  updateApp: (appId: string, updateAppData: Partial<ApplicationType>, edit: boolean) => void;
+  updateApp: (appId: string, updateAppData: Partial<ApplicationType>, type: string) => void;
   clearStorage: () => void;
   existingAppId: string;
 }
@@ -50,6 +52,7 @@ export const CreateApp = (props: CreateAppProps) => {
     query,
     name,
     description,
+    pplService,
     createApp,
     updateApp,
     setToasts,
@@ -72,6 +75,7 @@ export const CreateApp = (props: CreateAppProps) => {
     servicesEntities: [],
     traceGroups: [],
     panelId: '',
+    availabilityVisId: '',
   });
 
   useEffect(() => {
@@ -90,7 +94,15 @@ export const CreateApp = (props: CreateAppProps) => {
 
   useEffect(() => {
     if (editMode && existingAppId) {
-      fetchAppById(http, existingAppId, setExistingApp, setFilters, setToasts);
+      fetchAppById(
+        http,
+        pplService,
+        existingAppId,
+        setExistingApp,
+        setFilters,
+        () => {},
+        setToasts
+      );
     }
   }, [existingAppId]);
 
@@ -137,6 +149,7 @@ export const CreateApp = (props: CreateAppProps) => {
       servicesEntities: selectedServices.map((option) => option.label),
       traceGroups: selectedTraces.map((option) => option.label),
       panelId: '',
+      availabilityVisId: '',
     };
     createApp(appData);
   };
@@ -148,7 +161,7 @@ export const CreateApp = (props: CreateAppProps) => {
       servicesEntities: selectedServices.map((option) => option.label),
       traceGroups: selectedTraces.map((option) => option.label),
     };
-    updateApp(existingAppId, appData, true);
+    updateApp(existingAppId, appData, 'update');
   };
 
   const onCancel = () => {

--- a/dashboards-observability/public/components/application_analytics/helpers/utils.tsx
+++ b/dashboards-observability/public/components/application_analytics/helpers/utils.tsx
@@ -196,7 +196,7 @@ export const calculateAvailability = async (
   const panelId = application.panelId;
   if (!panelId) return availability;
   // Fetches saved visualizations associated to application's panel
-  const savedVisualizationsIds = await fetchPanelsVizIdList(http, panelId);
+  const savedVisualizationsIds = (await fetchPanelsVizIdList(http, panelId)).reverse();
   if (!savedVisualizationsIds) return availability;
   const visWithAvailability = [];
   let availabilityFound = false;

--- a/dashboards-observability/public/components/explorer/visualizations/config_panel/config_editor/config_controls/config_thresholds.tsx
+++ b/dashboards-observability/public/components/explorer/visualizations/config_panel/config_editor/config_controls/config_thresholds.tsx
@@ -66,7 +66,7 @@ export const ConfigThresholds = ({
             if (thrId !== th.thid) return th;
             return {
               ...th,
-              [thrName]: event?.target?.value || event,
+              [thrName]: event?.target?.value || '',
             };
           }),
         ]);
@@ -131,7 +131,7 @@ export const ConfigThresholds = ({
                     <EuiFieldNumber
                       fullWidth
                       placeholder="Placeholder text"
-                      value={thr.value || 0}
+                      value={thr.value}
                       onChange={handleThresholdChange(thr.thid, 'value')}
                       aria-label="Input threshold value"
                       data-test-subj="valueFieldNumber"

--- a/dashboards-observability/server/adaptors/application_analytics/app_analytics_adaptor.ts
+++ b/dashboards-observability/server/adaptors/application_analytics/app_analytics_adaptor.ts
@@ -23,7 +23,11 @@ export class AppAnalyticsAdaptor {
           id: application.objectId,
           panelId: application.application.panelId,
           composition: decodedComposition,
-          availability: {},
+          availability: {
+            name: '',
+            color: '',
+            mainVisId: application.application.availabilityVisId || '',
+          },
           dateModified: application.lastUpdatedTimeMs,
           dateCreated: application.createdTimeMs,
         };
@@ -34,7 +38,7 @@ export class AppAnalyticsAdaptor {
   };
 
   // Fetch application by id
-  fetchAppById = async (client: ILegacyScopedClusterClient, appId: string) => {
+  fetchAppById = async (client: ILegacyScopedClusterClient, appId: string): Promise<ApplicationType> => {
     try {
       const response = await client.callAsCurrentUser('observability.getObjectById', {
         objectId: appId,
@@ -52,7 +56,8 @@ export class AppAnalyticsAdaptor {
     description: string,
     baseQuery: string,
     servicesEntities: string[],
-    traceGroups: string[]
+    traceGroups: string[],
+    availabilityVisId: string
   ) => {
     const appBody = {
       name,
@@ -60,6 +65,7 @@ export class AppAnalyticsAdaptor {
       baseQuery,
       servicesEntities,
       traceGroups,
+      availabilityVisId,
     };
 
     try {

--- a/dashboards-observability/server/routes/application_analytics/app_analytics_router.ts
+++ b/dashboards-observability/server/routes/application_analytics/app_analytics_router.ts
@@ -2,6 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+/* eslint-disable no-console */
 
 import { schema } from '@osd/config-schema';
 import {
@@ -96,6 +97,7 @@ export function registerAppAnalyticsRouter(router: IRouter) {
           baseQuery: schema.string(),
           servicesEntities: schema.arrayOf(schema.string()),
           traceGroups: schema.arrayOf(schema.string()),
+          availabilityVisId: schema.maybe(schema.string()),
         }),
       },
     },
@@ -115,12 +117,13 @@ export function registerAppAnalyticsRouter(router: IRouter) {
           request.body.description || '',
           request.body.baseQuery,
           request.body.servicesEntities,
-          request.body.traceGroups
+          request.body.traceGroups,
+          request.body.availabilityVisId || ''
         );
         return response.ok({
           body: {
             message: 'Application Created',
-            newAppId: newAppId,
+            newAppId,
           },
         });
       } catch (err: any) {
@@ -187,6 +190,7 @@ export function registerAppAnalyticsRouter(router: IRouter) {
             servicesEntities: schema.maybe(schema.arrayOf(schema.string())),
             traceGroups: schema.maybe(schema.arrayOf(schema.string())),
             panelId: schema.maybe(schema.string()),
+            availabilityVisId: schema.maybe(schema.string()),
           }),
         }),
       },
@@ -209,7 +213,7 @@ export function registerAppAnalyticsRouter(router: IRouter) {
         return response.ok({
           body: {
             message: 'Application Updated',
-            updatedAppId: updatedAppId,
+            updatedAppId,
           },
         });
       } catch (err: any) {

--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/model/Application.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/model/Application.kt
@@ -36,8 +36,8 @@ import org.opensearch.observability.util.logger
  *       "Users.admin",
  *       "Purchase.source"
  *   ],
- *   "panelId": "rgfQfn4BCe7Q1SIYgrrj"
- * }
+ *   "panelId": "rgfQfn4BCe7Q1SIYgrrj",
+ *   "availabilityVisId": "co-Ha38BD0LU9um06tQP"
  * }</pre>
  */
 
@@ -47,7 +47,8 @@ internal data class Application(
     val baseQuery: String?,
     val servicesEntities: List<String>?,
     val traceGroups: List<String>?,
-    val panelId: String?
+    val panelId: String?,
+    val availabilityVisId: String?
 ) : BaseObjectData {
 
     internal companion object {
@@ -58,6 +59,7 @@ internal data class Application(
         private const val SERVICES_ENTITIES_TAG = "servicesEntities"
         private const val TRACE_GROUPS_TAG = "traceGroups"
         private const val PANEL_ID_TAG = "panelId"
+        private const val AVAILABILITY_VIS_ID_TAG = "availabilityVisId"
 
         /**
          * reader to create instance of class from writable.
@@ -81,6 +83,7 @@ internal data class Application(
             var servicesEntities: List<String>? = null
             var traceGroups: List<String>? = null
             var panelId: String? = null
+            var availabilityVisId: String? = null
             XContentParserUtils.ensureExpectedToken(
                 XContentParser.Token.START_OBJECT,
                 parser.currentToken(),
@@ -96,13 +99,14 @@ internal data class Application(
                     SERVICES_ENTITIES_TAG -> servicesEntities = parser.stringList()
                     TRACE_GROUPS_TAG -> traceGroups = parser.stringList()
                     PANEL_ID_TAG -> panelId = parser.text()
+                    AVAILABILITY_VIS_ID_TAG -> availabilityVisId = parser.text()
                     else -> {
                         parser.skipChildren()
                         log.info("$LOG_PREFIX:Application Skipping Unknown field $fieldName")
                     }
                 }
             }
-            return Application(name, description, baseQuery, servicesEntities, traceGroups, panelId)
+            return Application(name, description, baseQuery, servicesEntities, traceGroups, panelId, availabilityVisId)
         }
     }
 
@@ -125,7 +129,8 @@ internal data class Application(
         baseQuery = input.readString(),
         servicesEntities = input.readStringList(),
         traceGroups = input.readStringList(),
-        panelId = input.readString()
+        panelId = input.readString(),
+        availabilityVisId = input.readString()
     )
 
     /**
@@ -138,6 +143,7 @@ internal data class Application(
         output.writeStringCollection(servicesEntities)
         output.writeStringCollection(traceGroups)
         output.writeString(panelId)
+        output.writeString(availabilityVisId)
     }
 
     /**
@@ -152,6 +158,7 @@ internal data class Application(
             .fieldIfNotNull(SERVICES_ENTITIES_TAG, servicesEntities)
             .fieldIfNotNull(TRACE_GROUPS_TAG, traceGroups)
             .fieldIfNotNull(PANEL_ID_TAG, panelId)
+            .fieldIfNotNull(AVAILABILITY_VIS_ID_TAG, availabilityVisId)
         return builder.endObject()
     }
 }


### PR DESCRIPTION
Signed-off-by: Eugene Lee <eugenesk@amazon.com>

### Description
- Add `availabilityVisId` to application
  - This parameter keeps track of which visualization should be used to compute availability from
  - It is just an empty string until set
  - It is set when the user goes to the configuration tab and selects it from the options
  - When it isn't set the availability is set from the newest visualization

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
