### PR TITLE
Show saved time range when editing saved visualization

### DIFF
--- a/dashboards-observability/public/components/explorer/explorer.tsx
+++ b/dashboards-observability/public/components/explorer/explorer.tsx
@@ -227,6 +227,13 @@ export const Explorer = ({
         const currQuery = appLogEvents
           ? objectData?.query.replace(appBaseQuery + '| ', '')
           : objectData?.query || '';
+        
+        if (appLogEvents) {
+          if (objectData?.selected_date_range?.start && objectData?.selected_date_range?.end) {
+            setStartTime(objectData.selected_date_range.start);
+            setEndTime(objectData.selected_date_range.end);
+          }
+        }
 
         // update redux
         batch(async () => {


### PR DESCRIPTION
Signed-off-by: Eugene Lee <eugenesk@amazon.com>

### Description
The time range that is saved in the visualization is the one that should be set when we redirect to the edit view of a visualization.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
