### PR TITLE
Modularize and cleanup panel

### DIFF
--- a/dashboards-observability/.cypress/integration/app_analytics.spec.js
+++ b/dashboards-observability/.cypress/integration/app_analytics.spec.js
@@ -21,10 +21,14 @@ import {
   trace_one,
   trace_two,
   trace_three,
-  spanQueryPartOne,
-  spanQueryPartTwo,
-  spanQueryPartThree,
-  visName,
+  spanQueryOnePartOne,
+  spanQueryOnePartTwo,
+  spanQueryOnePartThree,
+  spanQueryTwoPartOne,
+  spanQueryTwoPartTwo,
+  spanQueryTwoPartThree,
+  visOneName,
+  visTwoName,
   composition,
   newName,
 } from '../utils/app_constants';
@@ -92,10 +96,22 @@ describe('Creating application', () => {
     cy.get('.euiBadge').contains('2').should('exist');
     cy.get('.euiButton').contains('Create').should('not.be.disabled');
     cy.get('.euiButton').contains('Create').click();
-    cy.wait(delay);
+    cy.wait(delay*3);
     cy.get('.euiTitle').contains(name).should('exist');
     cy.get('.euiTab').contains('Panel').click();
-    cy.get('.euiText').contains('Start by adding metrics').should('exist');
+    cy.get('.euiText').contains('Start by adding your first visualization').should('exist');
+  });
+
+  it('Hides application panels in Operational Panels', () => {
+    cy.visit(
+      `${Cypress.env('opensearchDashboards')}/app/observability-dashboards#/operational_panels/`
+    );
+    cy.wait(delay*3);
+    cy.get('input.euiFieldSearch').type(`${name}'s Panel`);
+    cy.wait(delay);
+    cy.get('.euiTableCellContent__text').contains('No items found').should('exist');
+    cy.get('.euiFormControlLayoutClearButton').click();
+    cy.wait(delay);
   });
 
   it('Redirects to home page on cancel', () => {
@@ -161,12 +177,12 @@ describe('Creating application', () => {
 });
 
 describe('Viewing application', () => {
-  before(() => {
+  beforeEach(() => {
     moveToApplication();
+    changeTimeTo24('months');
   })
 
   it('Shares time range among tabs', () => {
-    changeTimeTo24('months');
     cy.get('[data-test-subj="superDatePickerShowDatesButton"]').should('contain', 'Last 24 months');
     cy.get('.euiTab').contains('Services').click();
     cy.get('[data-test-subj="superDatePickerShowDatesButton"]').should('contain', 'Last 24 months');
@@ -254,20 +270,23 @@ describe('Viewing application', () => {
     cy.get('.euiBadge__text').contains('Base Query').should('exist');
   });
 
-  it('Saves visualization to panel', () => {
-    cy.get('.euiTab').contains('Log Events').click();
+  it('Saves visualization #1 to panel', () => {
+    cy.get('.euiTab').contains('Panel').click();
+    cy.get('.euiButton').eq(3).contains('Add').click();
+    cy.wait(delay);
     cy.get('.plot-container').should('exist');
     cy.get('[data-test-subj="searchAutocompleteTextArea"]').click();
     cy.get('.aa-List').find('.aa-Item').should('have.length', 11);
     cy.get('[data-test-subj="searchAutocompleteTextArea"]').type('x');
-    cy.get('[data-test-subj="searchAutocompleteTextArea"]').clear().wait(delay * 2).type(spanQueryPartOne);
-    cy.get('[data-test-subj="searchAutocompleteTextArea"]').wait(delay * 2).type(spanQueryPartTwo);
-    cy.get('[data-test-subj="searchAutocompleteTextArea"]').wait(delay * 2).type(spanQueryPartThree);
-    cy.get('.euiButton').contains('Refresh').click();
+    cy.get('[data-test-subj="searchAutocompleteTextArea"]').clear().wait(delay * 2).type(spanQueryOnePartOne);
+    cy.get('[data-test-subj="searchAutocompleteTextArea"]').wait(delay * 2).type(spanQueryOnePartTwo);
+    cy.get('[data-test-subj="searchAutocompleteTextArea"]').wait(delay * 2).type(spanQueryOnePartThree);
+    changeTimeTo24('months');
     cy.get('.euiTab').contains('Visualizations').click();
     supressResizeObserverIssue();
     cy.get('[data-test-subj="eventExplorer__saveManagementPopover"]').click();
-    cy.get('[data-test-subj="eventExplorer__querySaveName"]').click().type(visName);
+    cy.get('[data-test-subj="eventExplorer__querySaveName"]').click().type(visOneName);
+    cy.wait(delay);
     cy.get('[data-test-subj="eventExplorer__querySaveConfirm"]').click();
     cy.wait(delay);
     cy.get('.euiTab').contains('Panel').click();
@@ -275,13 +294,14 @@ describe('Viewing application', () => {
     cy.get('.js-plotly-plot').should('exist');
   });
 
-  it('Adds availability level to visualization', () => {
+  it('Adds availability level to visualization #1', () => {
     cy.get('.euiTab').contains('Panel').click();
     cy.wait(delay);
     cy.get('[aria-label="actionMenuButton"]').click();
     cy.get('.euiContextMenuItem').contains('Edit').click();
     supressResizeObserverIssue();
     cy.wait(delay);
+    changeTimeTo24('months');
     cy.get('.euiBadge').contains('Bar').click();
     cy.focused().type('{downArrow}');
     cy.focused().type('{enter}');
@@ -302,6 +322,100 @@ describe('Viewing application', () => {
     cy.wait(delay);
     cy.get('.js-plotly-plot').should('exist');
     cy.get('.textpoint').contains('Available').should('exist');
+    moveToHomePage();
+    cy.get('.euiBadge').contains('Available').should('exist');
+    cy.get('[style="background-color: rgb(84, 179, 153); color: rgb(0, 0, 0);"]').should('exist');
+  });
+
+  it('Saves visualization #2 to panel with availability level', () => {
+    cy.get('.euiTab').contains('Log Events').click();
+    cy.get('.plot-container').should('exist');
+    cy.get('[data-test-subj="searchAutocompleteTextArea"]').clear();
+    cy.get('[data-test-subj="searchAutocompleteTextArea"]').type('x');
+    cy.get('[data-test-subj="searchAutocompleteTextArea"]').clear().wait(delay * 2).type(spanQueryTwoPartOne);
+    cy.get('[data-test-subj="searchAutocompleteTextArea"]').wait(delay * 2).type(spanQueryTwoPartTwo);
+    cy.get('[data-test-subj="searchAutocompleteTextArea"]').wait(delay * 2).type(spanQueryTwoPartThree);
+    changeTimeTo24('months');
+    cy.get('.euiTab').contains('Visualizations').click();
+    supressResizeObserverIssue();
+    cy.get('.euiBadge').contains('Bar').click();
+    cy.focused().type('{downArrow}');
+    cy.focused().type('{enter}');
+    cy.wait(delay);
+    cy.get('.euiButton').contains('+ Add availability level').click();
+    cy.get('[data-test-subj="colorPickerAnchor"]').click();
+    cy.get('[aria-label="Select #9170B8 as the color"]').click();
+    cy.wait(delay);
+    cy.get('[data-test-subj="nameFieldText"]').click().type('Super');
+    cy.get('[data-test-subj="expressionSelect"]').select('<');
+    cy.get('[data-test-subj="valueFieldNumber"]').clear().type('5.5');
+    cy.get('[data-test-subj="visualizeEditorRenderButton"]').click();
+    cy.wait(delay);
+    cy.get('.euiButton').contains('+ Add availability level').click();
+    cy.get('[data-test-subj="colorPickerAnchor"]').first().click();
+    cy.get('[aria-label="Select #CA8EAE as the color"]').click();
+    cy.wait(delay);
+    cy.get('[data-test-subj="nameFieldText"]').first().click().type('Cool');
+    cy.get('[data-test-subj="expressionSelect"]').first().select('>');
+    cy.get('[data-test-subj="valueFieldNumber"]').first().clear().type('0');
+    cy.get('[data-test-subj="visualizeEditorRenderButton"]').click();
+    cy.wait(delay);
+    cy.get('[data-test-subj="eventExplorer__saveManagementPopover"]').click();
+    cy.get('[data-test-subj="eventExplorer__querySaveName"]').click().type(visTwoName);
+    cy.wait(delay);
+    cy.get('[data-test-subj="eventExplorer__querySaveConfirm"]').click();
+    cy.wait(delay);
+    cy.get('.euiTab').contains('Panel').click();
+    cy.wait(delay);
+    cy.get('.js-plotly-plot').should('have.length', 2);
+    moveToHomePage();
+    cy.get('.euiBadge').contains('Super').should('exist');
+    cy.get('[style="background-color: rgb(145, 112, 184); color: rgb(0, 0, 0);"]').should('exist');
+  });
+
+  it('Hides application visualizations in Event Analytics', () => {
+    cy.visit(`${Cypress.env('opensearchDashboards')}/app/observability-dashboards#/event_analytics`);
+    cy.wait(delay*3);
+    cy.get('input.euiFieldSearch').type(visOneName);
+    cy.wait(delay);
+    cy.get('.euiTableCellContent__text').contains('No items found').should('exist');
+    cy.get('input.euiFieldSearch').clear().type(visTwoName);
+    cy.wait(delay);
+    cy.get('.euiTableCellContent__text').contains('No items found').should('exist');
+    cy.get('.euiFormControlLayoutClearButton').click();
+    cy.wait(delay);
+  });
+
+  it('Hides application visualizations in Operational Panels', () => {
+    cy.visit(
+      `${Cypress.env('opensearchDashboards')}/app/observability-dashboards#/operational_panels/`
+    );
+    cy.wait(delay*3);
+    cy.get('.euiButton__text').contains('Actions').click();
+    cy.wait(delay);
+    cy.get('.euiContextMenuItem__text').contains('Add samples').click();
+    cy.wait(delay);
+    cy.get('.euiButton__text').contains('Yes').click();
+    cy.wait(delay*2);
+    cy.get('.euiLink').contains('[Logs] Web traffic Panel').first().click();
+    cy.wait(delay);
+    cy.get('.euiButton__text').contains('Add visualization').click();
+    cy.get('.euiContextMenuItem__text').contains('Select existing visualization').click();
+    cy.get('option').contains(visOneName).should('not.exist');
+    cy.get('option').contains(visTwoName).should('not.exist');
+    cy.visit(
+      `${Cypress.env('opensearchDashboards')}/app/observability-dashboards#/operational_panels/`
+    );
+    cy.wait(delay*3);
+    cy.get('input.euiFieldSearch').type('[Logs] Web traffic Panel');
+    cy.wait(delay);
+    cy.get('.euiTableRow').first().within(($row) => {
+      cy.get('.euiCheckbox').click();
+    });
+    cy.get('.euiButton__text').contains('Actions').click();
+    cy.wait(delay);
+    cy.get('.euiContextMenuItem__text').contains('Delete').click();
+    cy.wait(delay);
   });
 
   it('Configuration tab shows details', () => {
@@ -310,7 +424,23 @@ describe('Viewing application', () => {
     cy.get('.euiCodeBlock__code').contains(baseQuery).should('exist');
     cy.get('[aria-label="List of services and entities"]').find('li').should('have.length', 1);
     cy.get('[aria-label="List of trace groups"]').find('li').should('have.length', 2);
+    cy.get('option').should('have.length', 2);
   });
+
+
+  it('Changes availability visualization', () => {
+    cy.get('.euiTab').contains('Configuration').click();
+    cy.wait(delay);
+    cy.get('select').select(visOneName);
+    cy.wait(delay);
+    moveToHomePage();
+    cy.get('.euiBadge').contains('Available').should('exist');
+    cy.get('[style="background-color: rgb(84, 179, 153); color: rgb(0, 0, 0);"]').should('exist');
+    moveToApplication();
+    cy.get('.euiTab').contains('Configuration').click();
+    cy.wait(delay);
+    cy.get('select').find('option:selected').should('have.text', visOneName);
+  })
 });
 
 describe('Editing application', () => {

--- a/dashboards-observability/.cypress/integration/panels.spec.js
+++ b/dashboards-observability/.cypress/integration/panels.spec.js
@@ -183,6 +183,25 @@ describe('Testing a panel', () => {
     moveToTestPanel();
   });
 
+  it('Opens visualization flyout from empty panel', () => {
+    cy.get('.euiButton').eq(4).contains('Add visualization').click();
+    cy.wait(delay);
+    cy.get('.euiContextMenuItem__text').contains('Select existing visualization').click();
+    cy.wait(delay);
+    cy.get('.euiButton').contains('Cancel').click();
+    cy.get('.euiButton').eq(2).contains('Add visualization').click();
+    cy.wait(delay);
+    cy.get('.euiContextMenuItem__text').contains('Select existing visualization').click();
+    cy.wait(delay);
+    cy.get('.euiButton').contains('Cancel').click();
+    cy.get('.euiButton').contains('Add visualization').first().click();
+    cy.get('.euiContextMenuItem__text').contains('Create new visualization').click();
+    cy.wait(delay);
+    cy.get('.euiBreadcrumb').contains('Explorer').should('exist');
+    cy.get('.euiCallOut').contains('No results match your search criteria').should('exist');
+    moveToTestPanel();
+  });
+
   it('Duplicate the open panel', () => {
     cy.get('.euiButton__text').contains('Panel actions').click();
     cy.wait(delay);
@@ -226,9 +245,9 @@ describe('Testing a panel', () => {
   });
 
   it('Add existing visualization #1', () => {
-    cy.get('.euiButton__text').contains('Add Visualization').click();
+    cy.get('.euiButton__text').contains('Add visualization').click();
     cy.wait(delay);
-    cy.get('.euiContextMenuItem__text').contains('Select Existing Visualization').click();
+    cy.get('.euiContextMenuItem__text').contains('Select existing visualization').click();
     cy.wait(delay);
     cy.get('select').select(PPL_VISUALIZATIONS_NAMES[0]);
     cy.get('button[aria-label="refreshPreview"]').click();
@@ -240,9 +259,9 @@ describe('Testing a panel', () => {
   });
 
   it('Add existing visualization #2', () => {
-    cy.get('.euiButton__text').contains('Add Visualization').click();
+    cy.get('.euiButton__text').contains('Add visualization').click();
     cy.wait(delay);
-    cy.get('.euiContextMenuItem__text').contains('Select Existing Visualization').click();
+    cy.get('.euiContextMenuItem__text').contains('Select existing visualization').click();
     cy.wait(delay);
     cy.get('select').select(PPL_VISUALIZATIONS_NAMES[1]);
     cy.get('button[aria-label="refreshPreview"]').click();
@@ -353,9 +372,9 @@ describe('Testing a panel', () => {
   });
 
   it('Create new visualization and add to panel', () => {
-    cy.get('.euiButton__text').contains('Add Visualization').click();
+    cy.get('.euiButton__text').contains('Add visualization').click();
     cy.wait(delay);
-    cy.get('.euiContextMenuItem__text').contains('Create New Visualization').click();
+    cy.get('.euiContextMenuItem__text').contains('Create new visualization').click();
     cy.wait(delay * 3);
     cy.url().should('match', new RegExp('(.*)#/event_analytics/explorer'));
     cy.get('[id^=autocomplete-textarea]').type(PPL_VISUALIZATIONS[2]);

--- a/dashboards-observability/.cypress/utils/app_constants.js
+++ b/dashboards-observability/.cypress/utils/app_constants.js
@@ -5,7 +5,7 @@
 
 import { supressResizeObserverIssue } from './constants';
 
-export const delay = 700;
+export const delay = 1000;
 
 export const moveToHomePage = () => {
   cy.visit(`${Cypress.env('opensearchDashboards')}/app/observability-dashboards#/application_analytics/`);
@@ -24,7 +24,7 @@ export const moveToCreatePage = () => {
 
 export const moveToApplication = () => {
   cy.visit(`${Cypress.env('opensearchDashboards')}/app/observability-dashboards#/application_analytics/`);
-  cy.wait(delay * 5);
+  cy.wait(delay * 6);
   cy.get('.euiLink').contains(name).click();
   cy.wait(delay);
   cy.get('.euiTitle').contains(name).should('exist');
@@ -45,11 +45,19 @@ export const changeTimeTo24 = (timeUnit) => {
   cy.get('[aria-label="Time unit"]').select(timeUnit);
   cy.get('.euiButton').contains('Apply').click();
   cy.wait(delay);
+  cy.get('.euiButton').contains('Refresh').click();
 };
 
 export const expectMessageOnHover = (message) => {
   cy.get('.euiToolTipAnchor').contains('Create').click({ force: true });
   cy.get('.euiToolTipPopover').contains(message).should('exist');
+};
+
+export const moveToPanelHome = () => {
+  cy.visit(
+    `${Cypress.env('opensearchDashboards')}/app/observability-dashboards#/operational_panels/`
+  );
+  cy.wait(delay * 3);
 };
 
 export const baseQuery = 'source = opensearch_dashboards_sample_data_flights';
@@ -60,9 +68,13 @@ export const service_two = 'payment';
 export const trace_one = 'HTTP POST';
 export const trace_two = 'HTTP GET';
 export const trace_three = 'client_pay_order';
-export const spanQueryPartOne = 'where DestCityName ';
-export const spanQueryPartTwo = '= "Venice" | stats count() by span( timestamp ';
-export const spanQueryPartThree = ', 6h )';
-export const visName = 'Flights to Venice';
+export const spanQueryOnePartOne = 'where DestCityName ';
+export const spanQueryOnePartTwo = '= "Venice" | stats count() by span( timestamp ';
+export const spanQueryOnePartThree = ', 6h )';
+export const spanQueryTwoPartOne = 'where OriginCityName ';
+export const spanQueryTwoPartTwo = '= "Seoul" | stats count() by span( timestamp ';
+export const spanQueryTwoPartThree = ', 6h )';
+export const visOneName = 'Flights to Venice';
+export const visTwoName = 'Flights from Seoul';
 export const composition = 'order, payment, HTTP POST, HTTP GET, client_pay_order'
 export const newName = 'Monterey Cypress';

--- a/dashboards-observability/public/components/application_analytics/components/application.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/application.tsx
@@ -383,13 +383,13 @@ export function Application(props: AppDetailProps) {
         dslService={dslService}
         chrome={chrome}
         parentBreadcrumbs={parentBreadcrumbs}
+        childBreadcrumbs={childBreadcrumbs}
         // App analytics will not be renaming/cloning/deleting panels
         renameCustomPanel={async () => undefined}
         cloneCustomPanel={async () => Promise.reject()}
         deleteCustomPanel={async () => Promise.reject()}
         setToast={setToasts}
         page="app"
-        appName={application.name}
         appId={appId}
         startTime={startTime}
         endTime={endTime}

--- a/dashboards-observability/public/components/application_analytics/components/application.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/application.tsx
@@ -399,7 +399,7 @@ export function Application(props: AppDetailProps) {
         endTime={endTime}
         setStartTime={setStartTimeForApp}
         setEndTime={setEndTimeForApp}
-        switchToEvent={switchToEvent}
+        onAddClick={switchToEvent}
         onEditClick={onEditClick}
       />
     );

--- a/dashboards-observability/public/components/application_analytics/components/application.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/application.tsx
@@ -374,6 +374,10 @@ export function Application(props: AppDetailProps) {
     );
   };
 
+  const onEditClick = (savedVisualizationId: string) => {
+    switchToEditViz(savedVisualizationId);
+  };
+
   const getPanel = () => {
     return (
       <CustomPanelView
@@ -396,7 +400,7 @@ export function Application(props: AppDetailProps) {
         setStartTime={setStartTimeForApp}
         setEndTime={setEndTimeForApp}
         switchToEvent={switchToEvent}
-        switchToEditViz={switchToEditViz}
+        onEditClick={onEditClick}
       />
     );
   };

--- a/dashboards-observability/public/components/custom_panels/__tests__/custom_panel_view.test.tsx
+++ b/dashboards-observability/public/components/custom_panels/__tests__/custom_panel_view.test.tsx
@@ -42,6 +42,9 @@ describe.skip('Panels View Component', () => {
     const cloneCustomPanel = jest.fn();
     const deleteCustomPanel = jest.fn();
     const setToast = jest.fn();
+    const onEditClick = (savedVisId: string) => {
+      window.location.assign(`#/event_analytics/explorer/${savedVisId}`);
+    };
 
     const wrapper = mount(
       <CustomPanelView
@@ -55,6 +58,7 @@ describe.skip('Panels View Component', () => {
         cloneCustomPanel={cloneCustomPanel}
         deleteCustomPanel={deleteCustomPanel}
         setToast={setToast}
+        onEditClick={onEditClick}
         startTime={start}
         endTime={end}
         setStartTime={setStart}
@@ -97,6 +101,9 @@ describe.skip('Panels View Component', () => {
     const cloneCustomPanel = jest.fn();
     const deleteCustomPanel = jest.fn();
     const setToast = jest.fn();
+    const onEditClick = (savedVisId: string) => {
+      window.location.assign(`#/event_analytics/explorer/${savedVisId}`);
+    };
 
     const wrapper = mount(
       <CustomPanelView
@@ -110,6 +117,7 @@ describe.skip('Panels View Component', () => {
         cloneCustomPanel={cloneCustomPanel}
         deleteCustomPanel={deleteCustomPanel}
         setToast={setToast}
+        onEditClick={onEditClick}
         startTime={start}
         endTime={end}
         setStartTime={setStart}

--- a/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
+++ b/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
@@ -93,12 +93,12 @@ interface CustomPanelViewProps {
     text?: React.ReactChild | undefined,
     side?: string | undefined
   ) => void;
+  onEditClick: (savedVisualizationId: string) => any;
   startTime: string;
   endTime: string;
   setStartTime: any;
   setEndTime: any;
   switchToEvent?: any;
-  switchToEditViz?: any;
 }
 
 export const CustomPanelView = (props: CustomPanelViewProps) => {
@@ -120,8 +120,8 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
     deleteCustomPanel,
     cloneCustomPanel,
     setToast,
+    onEditClick,
     switchToEvent,
-    switchToEditViz,
   } = props;
   const [openPanelName, setOpenPanelName] = useState('');
   const [panelCreatedTime, setPanelCreatedTime] = useState('');
@@ -721,13 +721,12 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
               pplService={pplService}
               startTime={startTime}
               endTime={endTime}
-              fromApp={appPanel}
               onRefresh={onRefresh}
               cloneVisualization={cloneVisualization}
               pplFilterValue={pplFilterValue}
               showFlyout={showFlyout}
               editActionType={editActionType}
-              switchToEditViz={switchToEditViz}
+              onEditClick={onEditClick}
             />
           </EuiPageContentBody>
         </EuiPageBody>

--- a/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
+++ b/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
@@ -58,6 +58,7 @@ import {
   onItemSelect,
   parseForIndices,
 } from '../common/search/autocomplete_logic';
+import { AddVisualizationPopover } from './helpers/add_visualization_popover';
 
 /*
  * "CustomPanelsView" module used to render an Operational Panel
@@ -147,7 +148,6 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
   const [editMode, setEditMode] = useState(false);
   const [isModalVisible, setIsModalVisible] = useState(false); // Modal Toggle
   const [modalLayout, setModalLayout] = useState(<EuiOverlayMask />); // Modal Layout
-  const [isVizPopoverOpen, setVizPopoverOpen] = useState(false); // Add Visualization Popover
   const [isFlyoutVisible, setIsFlyoutVisible] = useState(false); // Add Visualization Flyout
   const [isFlyoutReplacement, setisFlyoutReplacement] = useState<boolean | undefined>(false);
   const [replaceVisualizationId, setReplaceVisualizationId] = useState<string | undefined>('');
@@ -170,37 +170,6 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
   // DateTimePicker States
   const [recentlyUsedRanges, setRecentlyUsedRanges] = useState<DurationRange[]>([]);
 
-  const getVizContextPanels = (closeVizPopover?: () => void) => {
-    return [
-      {
-        id: 0,
-        title: 'Add Visualization',
-        items: [
-          {
-            name: 'Select Existing Visualization',
-            onClick: () => {
-              if (closeVizPopover != null) {
-                closeVizPopover();
-              }
-              showFlyout();
-            },
-          },
-          {
-            name: 'Create New Visualization',
-            onClick: () => {
-              advancedVisualization();
-            },
-          },
-        ],
-      },
-    ];
-  };
-
-  const advancedVisualization = () => {
-    closeVizPopover();
-    window.location.assign('#/event_analytics/explorer');
-  };
-
   // Fetch Panel by id
   const fetchCustomPanel = async () => {
     return http
@@ -218,14 +187,6 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
       });
   };
 
-  const onPopoverClick = () => {
-    setVizPopoverOpen(!isVizPopoverOpen);
-  };
-
-  const closeVizPopover = () => {
-    setVizPopoverOpen(false);
-  };
-
   const handleQueryChange = (newQuery: string) => {
     setPPLFilterValue(newQuery);
   };
@@ -238,16 +199,16 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
     setIsModalVisible(true);
   };
 
-  const onDatePickerChange = (props: OnTimeChangeProps) => {
+  const onDatePickerChange = (timeProps: OnTimeChangeProps) => {
     onTimeChange(
-      props.start,
-      props.end,
+      timeProps.start,
+      timeProps.end,
       recentlyUsedRanges,
       setRecentlyUsedRanges,
       setStartTime,
       setEndTime
     );
-    onRefreshFilters(props.start, props.end);
+    onRefreshFilters(timeProps.start, timeProps.end);
   };
 
   const onDelete = async () => {
@@ -457,31 +418,6 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
     </EuiButton>
   );
 
-  // Add Visualization Button
-  const addVisualizationButton = (
-    <EuiButton
-      iconType="arrowDown"
-      iconSide="right"
-      disabled={addVizDisabled}
-      onClick={onPopoverClick}
-    >
-      Add Visualization
-    </EuiButton>
-  );
-
-  const addVisualizationPopover = (
-    <EuiPopover
-      id="addVisualizationContextMenu"
-      button={addVisualizationButton}
-      isOpen={isVizPopoverOpen}
-      closePopover={closeVizPopover}
-      panelPaddingSize="none"
-      anchorPosition="downLeft"
-    >
-      <EuiContextMenu initialPanelId={0} panels={getVizContextPanels(closeVizPopover)} />
-    </EuiPopover>
-  );
-
   // Panel Actions Button
   const panelActionsButton = (
     <EuiButton
@@ -626,7 +562,12 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
                         <EuiContextMenu initialPanelId={0} panels={panelActionsMenu} />
                       </EuiPopover>
                     </EuiFlexItem>
-                    <EuiFlexItem grow={false}>{addVisualizationPopover}</EuiFlexItem>
+                    <EuiFlexItem grow={false}>
+                      <AddVisualizationPopover
+                        addVizDisabled={addVizDisabled}
+                        showFlyout={showFlyout}
+                      />
+                    </EuiFlexItem>
                   </EuiFlexGroup>
                 </EuiPageHeaderSection>
               </>
@@ -688,7 +629,11 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
             </EuiFlexGroup>
             <EuiSpacer size="l" />
             {panelVisualizations.length === 0 && (
-              <EmptyPanelView addButton={appPanel ? addButton : addVisualizationButton} />
+              <EmptyPanelView
+                addVizDisabled={addVizDisabled}
+                showFlyout={showFlyout}
+                {...(appPanel ? { addButton } : {})}
+              />
             )}
             <PanelGrid
               http={http}

--- a/dashboards-observability/public/components/custom_panels/helpers/add_visualization_popover.tsx
+++ b/dashboards-observability/public/components/custom_panels/helpers/add_visualization_popover.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EuiButton, EuiContextMenu, EuiPopover } from '@elastic/eui';
+import React, { useState } from 'react';
+
+interface AddVisualizationPopoverProps {
+  showFlyout: (isReplacement?: boolean, replaceVizId?: string) => void;
+  addVizDisabled: boolean;
+}
+
+export const AddVisualizationPopover = ({
+  addVizDisabled,
+  showFlyout,
+}: AddVisualizationPopoverProps) => {
+  const [isVizPopoverOpen, setVizPopoverOpen] = useState(false); // Add Visualization Popover
+
+  const onPopoverClick = () => {
+    setVizPopoverOpen(!isVizPopoverOpen);
+  };
+
+  const closeVizPopover = () => {
+    setVizPopoverOpen(false);
+  };
+
+  const advancedVisualization = () => {
+    closeVizPopover();
+    window.location.assign('#/event_analytics/explorer');
+  };
+
+  const getVizContextPanels = () => {
+    return [
+      {
+        id: 0,
+        title: 'Add visualization',
+        items: [
+          {
+            name: 'Select existing visualization',
+            onClick: () => {
+              if (closeVizPopover != null) {
+                closeVizPopover();
+              }
+              showFlyout();
+            },
+          },
+          {
+            name: 'Create new visualization',
+            onClick: () => {
+              advancedVisualization();
+            },
+          },
+        ],
+      },
+    ];
+  };
+
+  const addVisualizationButton = (
+    <EuiButton
+      iconType="arrowDown"
+      iconSide="right"
+      disabled={addVizDisabled}
+      onClick={onPopoverClick}
+    >
+      Add visualization
+    </EuiButton>
+  );
+  return (
+    <EuiPopover
+      id="addVisualizationContextMenu"
+      button={addVisualizationButton}
+      isOpen={isVizPopoverOpen}
+      closePopover={closeVizPopover}
+      panelPaddingSize="none"
+      anchorPosition="downLeft"
+    >
+      <EuiContextMenu initialPanelId={0} panels={getVizContextPanels()} />
+    </EuiPopover>
+  );
+};

--- a/dashboards-observability/public/components/custom_panels/home.tsx
+++ b/dashboards-observability/public/components/custom_panels/home.tsx
@@ -40,7 +40,7 @@ import { isNameValid } from './helpers/utils';
  * renderProps: Props from router
  */
 
-interface Props {
+interface PanelHomeProps {
   http: CoreStart['http'];
   chrome: CoreStart['chrome'];
   parentBreadcrumbs: EuiBreadcrumb[];
@@ -56,7 +56,7 @@ export const Home = ({
   pplService,
   dslService,
   renderProps,
-}: Props) => {
+}: PanelHomeProps) => {
   const [customPanelData, setcustomPanelData] = useState<CustomPanelListType[]>([]);
   const [toasts, setToasts] = useState<Toast[]>([]);
   const [loading, setLoading] = useState(false);
@@ -68,6 +68,10 @@ export const Home = ({
     if (!text) text = '';
     setToastRightSide(!side ? true : false);
     setToasts([...toasts, { id: new Date().toISOString(), title, text, color } as Toast]);
+  };
+
+  const onEditClick = (savedVisualizationId: string) => {
+    window.location.assign(`#/event_analytics/explorer/${savedVisualizationId}`);
   };
 
   // Fetches all saved Custom Panels
@@ -330,6 +334,7 @@ export const Home = ({
               cloneCustomPanel={cloneCustomPanel}
               deleteCustomPanel={deleteCustomPanel}
               setToast={setToast}
+              onEditClick={onEditClick}
               startTime={start}
               endTime={end}
               setStartTime={setStart}

--- a/dashboards-observability/public/components/custom_panels/panel_modules/__tests__/__snapshots__/empty_panel.test.tsx.snap
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/__tests__/__snapshots__/empty_panel.test.tsx.snap
@@ -2,23 +2,33 @@
 
 exports[`Empty panel view component renders empty panel view with disabled popover 1`] = `
 <EmptyPanelView
-  addVizDisabled={true}
-  getVizContextPanels={
-    [MockFunction] {
-      "calls": Array [
-        Array [
-          [Function],
-        ],
-      ],
-      "results": Array [
-        Object {
-          "type": "return",
-          "value": undefined,
-        },
-      ],
-    }
+  addButton={
+    <EuiPopover
+      anchorPosition="downLeft"
+      button={
+        <EuiButton
+          disabled={true}
+          iconSide="right"
+          iconType="arrowDown"
+          onClick={[MockFunction]}
+        >
+          Add Visualization
+        </EuiButton>
+      }
+      closePopover={[MockFunction]}
+      display="inlineBlock"
+      hasArrow={true}
+      id="addVisualizationContextMenu"
+      isOpen={false}
+      ownFocus={false}
+      panelPaddingSize="none"
+    >
+      <EuiContextMenu
+        initialPanelId={0}
+        panels={Array []}
+      />
+    </EuiPopover>
   }
-  page="operationalPanel"
 >
   <div>
     <EuiSpacer
@@ -41,8 +51,7 @@ exports[`Empty panel view component renders empty panel view with disabled popov
             className="euiTextAlign euiTextAlign--center"
           >
             <h2>
-              Start by adding 
-              your first visualization
+              Start by adding your first visualization
             </h2>
             <EuiSpacer
               size="m"
@@ -65,8 +74,7 @@ exports[`Empty panel view component renders empty panel view with disabled popov
                   <div
                     className="euiTextColor euiTextColor--subdued"
                   >
-                    Use PPL Queries to fetch & filter observability data and create
-                     visualizations
+                    Use PPL Queries to fetch & filter observability data and create visualizations
                   </div>
                 </EuiTextColor>
               </div>
@@ -101,12 +109,12 @@ exports[`Empty panel view component renders empty panel view with disabled popov
                   disabled={true}
                   iconSide="right"
                   iconType="arrowDown"
-                  onClick={[Function]}
+                  onClick={[MockFunction]}
                 >
                   Add Visualization
                 </EuiButton>
               }
-              closePopover={[Function]}
+              closePopover={[MockFunction]}
               display="inlineBlock"
               hasArrow={true}
               id="addVisualizationContextMenu"
@@ -116,7 +124,7 @@ exports[`Empty panel view component renders empty panel view with disabled popov
             >
               <EuiOutsideClickDetector
                 isDisabled={true}
-                onOutsideClick={[Function]}
+                onOutsideClick={[MockFunction]}
               >
                 <div
                   className="euiPopover euiPopover--anchorDownLeft"
@@ -134,7 +142,7 @@ exports[`Empty panel view component renders empty panel view with disabled popov
                       disabled={true}
                       iconSide="right"
                       iconType="arrowDown"
-                      onClick={[Function]}
+                      onClick={[MockFunction]}
                     >
                       <EuiButtonDisplay
                         disabled={true}
@@ -142,13 +150,13 @@ exports[`Empty panel view component renders empty panel view with disabled popov
                         iconSide="right"
                         iconType="arrowDown"
                         isDisabled={true}
-                        onClick={[Function]}
+                        onClick={[MockFunction]}
                         type="button"
                       >
                         <button
                           className="euiButton euiButton--primary euiButton-isDisabled"
                           disabled={true}
-                          onClick={[Function]}
+                          onClick={[MockFunction]}
                           type="button"
                         >
                           <EuiButtonContent
@@ -220,23 +228,33 @@ exports[`Empty panel view component renders empty panel view with disabled popov
 
 exports[`Empty panel view component renders empty panel view with enabled popover 1`] = `
 <EmptyPanelView
-  addVizDisabled={false}
-  getVizContextPanels={
-    [MockFunction] {
-      "calls": Array [
-        Array [
-          [Function],
-        ],
-      ],
-      "results": Array [
-        Object {
-          "type": "return",
-          "value": undefined,
-        },
-      ],
-    }
+  addButton={
+    <EuiPopover
+      anchorPosition="downLeft"
+      button={
+        <EuiButton
+          disabled={false}
+          iconSide="right"
+          iconType="arrowDown"
+          onClick={[MockFunction]}
+        >
+          Add Visualization
+        </EuiButton>
+      }
+      closePopover={[MockFunction]}
+      display="inlineBlock"
+      hasArrow={true}
+      id="addVisualizationContextMenu"
+      isOpen={false}
+      ownFocus={false}
+      panelPaddingSize="none"
+    >
+      <EuiContextMenu
+        initialPanelId={0}
+        panels={Array []}
+      />
+    </EuiPopover>
   }
-  page="operationalPanel"
 >
   <div>
     <EuiSpacer
@@ -259,8 +277,7 @@ exports[`Empty panel view component renders empty panel view with enabled popove
             className="euiTextAlign euiTextAlign--center"
           >
             <h2>
-              Start by adding 
-              your first visualization
+              Start by adding your first visualization
             </h2>
             <EuiSpacer
               size="m"
@@ -283,8 +300,7 @@ exports[`Empty panel view component renders empty panel view with enabled popove
                   <div
                     className="euiTextColor euiTextColor--subdued"
                   >
-                    Use PPL Queries to fetch & filter observability data and create
-                     visualizations
+                    Use PPL Queries to fetch & filter observability data and create visualizations
                   </div>
                 </EuiTextColor>
               </div>
@@ -319,12 +335,12 @@ exports[`Empty panel view component renders empty panel view with enabled popove
                   disabled={false}
                   iconSide="right"
                   iconType="arrowDown"
-                  onClick={[Function]}
+                  onClick={[MockFunction]}
                 >
                   Add Visualization
                 </EuiButton>
               }
-              closePopover={[Function]}
+              closePopover={[MockFunction]}
               display="inlineBlock"
               hasArrow={true}
               id="addVisualizationContextMenu"
@@ -334,7 +350,7 @@ exports[`Empty panel view component renders empty panel view with enabled popove
             >
               <EuiOutsideClickDetector
                 isDisabled={true}
-                onOutsideClick={[Function]}
+                onOutsideClick={[MockFunction]}
               >
                 <div
                   className="euiPopover euiPopover--anchorDownLeft"
@@ -352,7 +368,7 @@ exports[`Empty panel view component renders empty panel view with enabled popove
                       disabled={false}
                       iconSide="right"
                       iconType="arrowDown"
-                      onClick={[Function]}
+                      onClick={[MockFunction]}
                     >
                       <EuiButtonDisplay
                         disabled={false}
@@ -360,13 +376,13 @@ exports[`Empty panel view component renders empty panel view with enabled popove
                         iconSide="right"
                         iconType="arrowDown"
                         isDisabled={false}
-                        onClick={[Function]}
+                        onClick={[MockFunction]}
                         type="button"
                       >
                         <button
                           className="euiButton euiButton--primary"
                           disabled={false}
-                          onClick={[Function]}
+                          onClick={[MockFunction]}
                           type="button"
                         >
                           <EuiButtonContent

--- a/dashboards-observability/public/components/custom_panels/panel_modules/__tests__/__snapshots__/empty_panel.test.tsx.snap
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/__tests__/__snapshots__/empty_panel.test.tsx.snap
@@ -2,33 +2,8 @@
 
 exports[`Empty panel view component renders empty panel view with disabled popover 1`] = `
 <EmptyPanelView
-  addButton={
-    <EuiPopover
-      anchorPosition="downLeft"
-      button={
-        <EuiButton
-          disabled={true}
-          iconSide="right"
-          iconType="arrowDown"
-          onClick={[MockFunction]}
-        >
-          Add Visualization
-        </EuiButton>
-      }
-      closePopover={[MockFunction]}
-      display="inlineBlock"
-      hasArrow={true}
-      id="addVisualizationContextMenu"
-      isOpen={false}
-      ownFocus={false}
-      panelPaddingSize="none"
-    >
-      <EuiContextMenu
-        initialPanelId={0}
-        panels={Array []}
-      />
-    </EuiPopover>
-  }
+  addVizDisabled={true}
+  showFlyout={[MockFunction]}
 >
   <div>
     <EuiSpacer
@@ -102,115 +77,120 @@ exports[`Empty panel view component renders empty panel view with disabled popov
           <div
             className="euiFlexItem euiFlexItem--flexGrowZero"
           >
-            <EuiPopover
-              anchorPosition="downLeft"
-              button={
-                <EuiButton
-                  disabled={true}
-                  iconSide="right"
-                  iconType="arrowDown"
-                  onClick={[MockFunction]}
-                >
-                  Add Visualization
-                </EuiButton>
-              }
-              closePopover={[MockFunction]}
-              display="inlineBlock"
-              hasArrow={true}
-              id="addVisualizationContextMenu"
-              isOpen={false}
-              ownFocus={false}
-              panelPaddingSize="none"
+            <AddVisualizationPopover
+              addVizDisabled={true}
+              showFlyout={[MockFunction]}
             >
-              <EuiOutsideClickDetector
-                isDisabled={true}
-                onOutsideClick={[MockFunction]}
+              <EuiPopover
+                anchorPosition="downLeft"
+                button={
+                  <EuiButton
+                    disabled={true}
+                    iconSide="right"
+                    iconType="arrowDown"
+                    onClick={[Function]}
+                  >
+                    Add visualization
+                  </EuiButton>
+                }
+                closePopover={[Function]}
+                display="inlineBlock"
+                hasArrow={true}
+                id="addVisualizationContextMenu"
+                isOpen={false}
+                ownFocus={false}
+                panelPaddingSize="none"
               >
-                <div
-                  className="euiPopover euiPopover--anchorDownLeft"
-                  id="addVisualizationContextMenu"
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchStart={[Function]}
+                <EuiOutsideClickDetector
+                  isDisabled={true}
+                  onOutsideClick={[Function]}
                 >
                   <div
-                    className="euiPopover__anchor"
+                    className="euiPopover euiPopover--anchorDownLeft"
+                    id="addVisualizationContextMenu"
+                    onKeyDown={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
                   >
-                    <EuiButton
-                      disabled={true}
-                      iconSide="right"
-                      iconType="arrowDown"
-                      onClick={[MockFunction]}
+                    <div
+                      className="euiPopover__anchor"
                     >
-                      <EuiButtonDisplay
+                      <EuiButton
                         disabled={true}
-                        element="button"
                         iconSide="right"
                         iconType="arrowDown"
-                        isDisabled={true}
-                        onClick={[MockFunction]}
-                        type="button"
+                        onClick={[Function]}
                       >
-                        <button
-                          className="euiButton euiButton--primary euiButton-isDisabled"
+                        <EuiButtonDisplay
                           disabled={true}
-                          onClick={[MockFunction]}
+                          element="button"
+                          iconSide="right"
+                          iconType="arrowDown"
+                          isDisabled={true}
+                          onClick={[Function]}
                           type="button"
                         >
-                          <EuiButtonContent
-                            className="euiButton__content"
-                            iconSide="right"
-                            iconType="arrowDown"
-                            textProps={
-                              Object {
-                                "className": "euiButton__text",
-                              }
-                            }
+                          <button
+                            className="euiButton euiButton--primary euiButton-isDisabled"
+                            disabled={true}
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <span
-                              className="euiButtonContent euiButtonContent--iconRight euiButton__content"
+                            <EuiButtonContent
+                              className="euiButton__content"
+                              iconSide="right"
+                              iconType="arrowDown"
+                              textProps={
+                                Object {
+                                  "className": "euiButton__text",
+                                }
+                              }
                             >
-                              <EuiIcon
-                                className="euiButtonContent__icon"
-                                size="m"
-                                type="arrowDown"
+                              <span
+                                className="euiButtonContent euiButtonContent--iconRight euiButton__content"
                               >
-                                <EuiIconEmpty
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiIcon-isLoading euiButtonContent__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
+                                <EuiIcon
+                                  className="euiButtonContent__icon"
+                                  size="m"
+                                  type="arrowDown"
                                 >
-                                  <svg
+                                  <EuiIconEmpty
                                     aria-hidden={true}
                                     className="euiIcon euiIcon--medium euiIcon-isLoading euiButtonContent__icon"
                                     focusable="false"
-                                    height={16}
                                     role="img"
                                     style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  />
-                                </EuiIconEmpty>
-                              </EuiIcon>
-                              <span
-                                className="euiButton__text"
-                              >
-                                Add Visualization
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiIcon-isLoading euiButtonContent__icon"
+                                      focusable="false"
+                                      height={16}
+                                      role="img"
+                                      style={null}
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    />
+                                  </EuiIconEmpty>
+                                </EuiIcon>
+                                <span
+                                  className="euiButton__text"
+                                >
+                                  Add visualization
+                                </span>
                               </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonDisplay>
-                    </EuiButton>
+                            </EuiButtonContent>
+                          </button>
+                        </EuiButtonDisplay>
+                      </EuiButton>
+                    </div>
                   </div>
-                </div>
-              </EuiOutsideClickDetector>
-            </EuiPopover>
+                </EuiOutsideClickDetector>
+              </EuiPopover>
+            </AddVisualizationPopover>
           </div>
         </EuiFlexItem>
       </div>
@@ -228,33 +208,8 @@ exports[`Empty panel view component renders empty panel view with disabled popov
 
 exports[`Empty panel view component renders empty panel view with enabled popover 1`] = `
 <EmptyPanelView
-  addButton={
-    <EuiPopover
-      anchorPosition="downLeft"
-      button={
-        <EuiButton
-          disabled={false}
-          iconSide="right"
-          iconType="arrowDown"
-          onClick={[MockFunction]}
-        >
-          Add Visualization
-        </EuiButton>
-      }
-      closePopover={[MockFunction]}
-      display="inlineBlock"
-      hasArrow={true}
-      id="addVisualizationContextMenu"
-      isOpen={false}
-      ownFocus={false}
-      panelPaddingSize="none"
-    >
-      <EuiContextMenu
-        initialPanelId={0}
-        panels={Array []}
-      />
-    </EuiPopover>
-  }
+  addVizDisabled={false}
+  showFlyout={[MockFunction]}
 >
   <div>
     <EuiSpacer
@@ -328,120 +283,125 @@ exports[`Empty panel view component renders empty panel view with enabled popove
           <div
             className="euiFlexItem euiFlexItem--flexGrowZero"
           >
-            <EuiPopover
-              anchorPosition="downLeft"
-              button={
-                <EuiButton
-                  disabled={false}
-                  iconSide="right"
-                  iconType="arrowDown"
-                  onClick={[MockFunction]}
-                >
-                  Add Visualization
-                </EuiButton>
-              }
-              closePopover={[MockFunction]}
-              display="inlineBlock"
-              hasArrow={true}
-              id="addVisualizationContextMenu"
-              isOpen={false}
-              ownFocus={false}
-              panelPaddingSize="none"
+            <AddVisualizationPopover
+              addVizDisabled={false}
+              showFlyout={[MockFunction]}
             >
-              <EuiOutsideClickDetector
-                isDisabled={true}
-                onOutsideClick={[MockFunction]}
+              <EuiPopover
+                anchorPosition="downLeft"
+                button={
+                  <EuiButton
+                    disabled={false}
+                    iconSide="right"
+                    iconType="arrowDown"
+                    onClick={[Function]}
+                  >
+                    Add visualization
+                  </EuiButton>
+                }
+                closePopover={[Function]}
+                display="inlineBlock"
+                hasArrow={true}
+                id="addVisualizationContextMenu"
+                isOpen={false}
+                ownFocus={false}
+                panelPaddingSize="none"
               >
-                <div
-                  className="euiPopover euiPopover--anchorDownLeft"
-                  id="addVisualizationContextMenu"
-                  onKeyDown={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchStart={[Function]}
+                <EuiOutsideClickDetector
+                  isDisabled={true}
+                  onOutsideClick={[Function]}
                 >
                   <div
-                    className="euiPopover__anchor"
+                    className="euiPopover euiPopover--anchorDownLeft"
+                    id="addVisualizationContextMenu"
+                    onKeyDown={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchStart={[Function]}
                   >
-                    <EuiButton
-                      disabled={false}
-                      iconSide="right"
-                      iconType="arrowDown"
-                      onClick={[MockFunction]}
+                    <div
+                      className="euiPopover__anchor"
                     >
-                      <EuiButtonDisplay
+                      <EuiButton
                         disabled={false}
-                        element="button"
                         iconSide="right"
                         iconType="arrowDown"
-                        isDisabled={false}
-                        onClick={[MockFunction]}
-                        type="button"
+                        onClick={[Function]}
                       >
-                        <button
-                          className="euiButton euiButton--primary"
+                        <EuiButtonDisplay
                           disabled={false}
-                          onClick={[MockFunction]}
+                          element="button"
+                          iconSide="right"
+                          iconType="arrowDown"
+                          isDisabled={false}
+                          onClick={[Function]}
                           type="button"
                         >
-                          <EuiButtonContent
-                            className="euiButton__content"
-                            iconSide="right"
-                            iconType="arrowDown"
-                            textProps={
-                              Object {
-                                "className": "euiButton__text",
-                              }
-                            }
+                          <button
+                            className="euiButton euiButton--primary"
+                            disabled={false}
+                            onClick={[Function]}
+                            type="button"
                           >
-                            <span
-                              className="euiButtonContent euiButtonContent--iconRight euiButton__content"
+                            <EuiButtonContent
+                              className="euiButton__content"
+                              iconSide="right"
+                              iconType="arrowDown"
+                              textProps={
+                                Object {
+                                  "className": "euiButton__text",
+                                }
+                              }
                             >
-                              <EuiIcon
-                                className="euiButtonContent__icon"
-                                size="m"
-                                type="arrowDown"
+                              <span
+                                className="euiButtonContent euiButtonContent--iconRight euiButton__content"
                               >
-                                <EuiIconArrowDown
-                                  aria-hidden={true}
-                                  className="euiIcon euiIcon--medium euiButtonContent__icon"
-                                  focusable="false"
-                                  role="img"
-                                  style={null}
+                                <EuiIcon
+                                  className="euiButtonContent__icon"
+                                  size="m"
+                                  type="arrowDown"
                                 >
-                                  <svg
+                                  <EuiIconArrowDown
                                     aria-hidden={true}
                                     className="euiIcon euiIcon--medium euiButtonContent__icon"
                                     focusable="false"
-                                    height={16}
                                     role="img"
                                     style={null}
-                                    viewBox="0 0 16 16"
-                                    width={16}
-                                    xmlns="http://www.w3.org/2000/svg"
                                   >
-                                    <path
-                                      d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
-                                      fillRule="non-zero"
-                                    />
-                                  </svg>
-                                </EuiIconArrowDown>
-                              </EuiIcon>
-                              <span
-                                className="euiButton__text"
-                              >
-                                Add Visualization
+                                    <svg
+                                      aria-hidden={true}
+                                      className="euiIcon euiIcon--medium euiButtonContent__icon"
+                                      focusable="false"
+                                      height={16}
+                                      role="img"
+                                      style={null}
+                                      viewBox="0 0 16 16"
+                                      width={16}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                                        fillRule="non-zero"
+                                      />
+                                    </svg>
+                                  </EuiIconArrowDown>
+                                </EuiIcon>
+                                <span
+                                  className="euiButton__text"
+                                >
+                                  Add visualization
+                                </span>
                               </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonDisplay>
-                    </EuiButton>
+                            </EuiButtonContent>
+                          </button>
+                        </EuiButtonDisplay>
+                      </EuiButton>
+                    </div>
                   </div>
-                </div>
-              </EuiOutsideClickDetector>
-            </EuiPopover>
+                </EuiOutsideClickDetector>
+              </EuiPopover>
+            </AddVisualizationPopover>
           </div>
         </EuiFlexItem>
       </div>

--- a/dashboards-observability/public/components/custom_panels/panel_modules/__tests__/empty_panel.test.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/__tests__/empty_panel.test.tsx
@@ -14,34 +14,10 @@ describe('Empty panel view component', () => {
 
   it('renders empty panel view with disabled popover', () => {
     const addVizDisabled = true;
-    const onPopoverClick = jest.fn();
-    const isVizPopoverOpen = false;
-    const closeVizPopover = jest.fn();
-    const getVizContextPanels = jest.fn();
-    const addVisualizationButton = (
-      <EuiButton
-        iconType="arrowDown"
-        iconSide="right"
-        disabled={addVizDisabled}
-        onClick={onPopoverClick}
-      >
-        Add Visualization
-      </EuiButton>
+    const showFlyout = jest.fn();
+    const wrapper = mount(
+      <EmptyPanelView addVizDisabled={addVizDisabled} showFlyout={showFlyout} />
     );
-
-    const addVisualizationPopover = (
-      <EuiPopover
-        id="addVisualizationContextMenu"
-        button={addVisualizationButton}
-        isOpen={isVizPopoverOpen}
-        closePopover={closeVizPopover}
-        panelPaddingSize="none"
-        anchorPosition="downLeft"
-      >
-        <EuiContextMenu initialPanelId={0} panels={getVizContextPanels(closeVizPopover)} />
-      </EuiPopover>
-    );
-    const wrapper = mount(<EmptyPanelView addButton={addVisualizationPopover} />);
 
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find('EuiButton').prop('disabled')).toBe(true);
@@ -49,34 +25,10 @@ describe('Empty panel view component', () => {
 
   it('renders empty panel view with enabled popover', () => {
     const addVizDisabled = false;
-    const onPopoverClick = jest.fn();
-    const isVizPopoverOpen = false;
-    const closeVizPopover = jest.fn();
-    const getVizContextPanels = jest.fn();
-    const addVisualizationButton = (
-      <EuiButton
-        iconType="arrowDown"
-        iconSide="right"
-        disabled={addVizDisabled}
-        onClick={onPopoverClick}
-      >
-        Add Visualization
-      </EuiButton>
+    const showFlyout = jest.fn();
+    const wrapper = mount(
+      <EmptyPanelView addVizDisabled={addVizDisabled} showFlyout={showFlyout} />
     );
-
-    const addVisualizationPopover = (
-      <EuiPopover
-        id="addVisualizationContextMenu"
-        button={addVisualizationButton}
-        isOpen={isVizPopoverOpen}
-        closePopover={closeVizPopover}
-        panelPaddingSize="none"
-        anchorPosition="downLeft"
-      >
-        <EuiContextMenu initialPanelId={0} panels={getVizContextPanels(closeVizPopover)} />
-      </EuiPopover>
-    );
-    const wrapper = mount(<EmptyPanelView addButton={addVisualizationPopover} />);
 
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find('EuiButton').prop('disabled')).toBe(false);

--- a/dashboards-observability/public/components/custom_panels/panel_modules/__tests__/empty_panel.test.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/__tests__/empty_panel.test.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { EuiButton, EuiContextMenu, EuiPopover } from '@elastic/eui';
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
@@ -12,28 +13,70 @@ describe('Empty panel view component', () => {
   configure({ adapter: new Adapter() });
 
   it('renders empty panel view with disabled popover', () => {
+    const addVizDisabled = true;
+    const onPopoverClick = jest.fn();
+    const isVizPopoverOpen = false;
+    const closeVizPopover = jest.fn();
     const getVizContextPanels = jest.fn();
-    const wrapper = mount(
-      <EmptyPanelView
-        page="operationalPanel"
-        addVizDisabled={true}
-        getVizContextPanels={getVizContextPanels}
-      />
+    const addVisualizationButton = (
+      <EuiButton
+        iconType="arrowDown"
+        iconSide="right"
+        disabled={addVizDisabled}
+        onClick={onPopoverClick}
+      >
+        Add Visualization
+      </EuiButton>
     );
+
+    const addVisualizationPopover = (
+      <EuiPopover
+        id="addVisualizationContextMenu"
+        button={addVisualizationButton}
+        isOpen={isVizPopoverOpen}
+        closePopover={closeVizPopover}
+        panelPaddingSize="none"
+        anchorPosition="downLeft"
+      >
+        <EuiContextMenu initialPanelId={0} panels={getVizContextPanels(closeVizPopover)} />
+      </EuiPopover>
+    );
+    const wrapper = mount(<EmptyPanelView addButton={addVisualizationPopover} />);
 
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find('EuiButton').prop('disabled')).toBe(true);
   });
 
   it('renders empty panel view with enabled popover', () => {
+    const addVizDisabled = false;
+    const onPopoverClick = jest.fn();
+    const isVizPopoverOpen = false;
+    const closeVizPopover = jest.fn();
     const getVizContextPanels = jest.fn();
-    const wrapper = mount(
-      <EmptyPanelView
-        page="operationalPanel"
-        addVizDisabled={false}
-        getVizContextPanels={getVizContextPanels}
-      />
+    const addVisualizationButton = (
+      <EuiButton
+        iconType="arrowDown"
+        iconSide="right"
+        disabled={addVizDisabled}
+        onClick={onPopoverClick}
+      >
+        Add Visualization
+      </EuiButton>
     );
+
+    const addVisualizationPopover = (
+      <EuiPopover
+        id="addVisualizationContextMenu"
+        button={addVisualizationButton}
+        isOpen={isVizPopoverOpen}
+        closePopover={closeVizPopover}
+        panelPaddingSize="none"
+        anchorPosition="downLeft"
+      >
+        <EuiContextMenu initialPanelId={0} panels={getVizContextPanels(closeVizPopover)} />
+      </EuiPopover>
+    );
+    const wrapper = mount(<EmptyPanelView addButton={addVisualizationPopover} />);
 
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.find('EuiButton').prop('disabled')).toBe(false);

--- a/dashboards-observability/public/components/custom_panels/panel_modules/empty_panel.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/empty_panel.tsx
@@ -3,16 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  EuiSpacer,
-  EuiText,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiButton,
-  EuiPopover,
-  EuiContextMenu,
-} from '@elastic/eui';
-import React, { useState } from 'react';
+import { EuiSpacer, EuiText, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import React from 'react';
 
 /*
  * EmptyPanelView - This Sub-component is shown to the user when a operational panel is empty
@@ -22,84 +14,24 @@ import React, { useState } from 'react';
  * getVizContextPanels -> Function to populate the add visualization popover
  */
 
-interface Props {
-  addVizDisabled: boolean;
-  page: 'app' | 'operationalPanels';
-  getVizContextPanels: (
-    closeVizPopover?: (() => void) | undefined
-  ) => Array<{
-    id: number;
-    title: string;
-    items: Array<{
-      name: string;
-      onClick: () => void;
-    }>;
-  }>;
-  switchToEvent?: any;
+interface EmptyPanelViewProps {
+  addButton: any;
 }
 
-export const EmptyPanelView = ({
-  addVizDisabled,
-  page,
-  getVizContextPanels,
-  switchToEvent,
-}: Props) => {
-  const [isVizPopoverOpen, setVizPopoverOpen] = useState(false);
-  const appMetrics = page === 'app';
-
-  const onPopoverClick = () => {
-    setVizPopoverOpen(!isVizPopoverOpen);
-  };
-
-  const closeVizPopover = () => {
-    setVizPopoverOpen(false);
-  };
-
-  // Add Visualization Button
-  const addVisualizationButton = (
-    <EuiButton
-      iconType="arrowDown"
-      iconSide="right"
-      disabled={addVizDisabled}
-      onClick={onPopoverClick}
-    >
-      Add Visualization
-    </EuiButton>
-  );
-
+export const EmptyPanelView = ({ addButton }: EmptyPanelViewProps) => {
   return (
     <div>
       <EuiSpacer size="xxl" />
       <EuiText textAlign="center">
-        <h2>Start by adding {appMetrics ? 'metrics' : 'your first visualization'}</h2>
+        <h2>Start by adding your first visualization</h2>
         <EuiSpacer size="m" />
         <EuiText color="subdued" size="m">
-          Use PPL Queries to fetch &amp; filter observability data and create
-          {appMetrics ? ' metrics' : ' visualizations'}
+          Use PPL Queries to fetch &amp; filter observability data and create visualizations
         </EuiText>
       </EuiText>
       <EuiSpacer size="m" />
       <EuiFlexGroup justifyContent="center">
-        {appMetrics ? (
-          <EuiFlexItem grow={false}>
-            <EuiButton iconType="plusInCircle" onClick={switchToEvent} isDisabled={addVizDisabled}>
-              Add
-            </EuiButton>
-          </EuiFlexItem>
-        ) : (
-          <EuiFlexItem grow={false}>
-            <EuiPopover
-              id="addVisualizationContextMenu"
-              button={addVisualizationButton}
-              isOpen={isVizPopoverOpen}
-              closePopover={closeVizPopover}
-              panelPaddingSize="none"
-              anchorPosition="downLeft"
-            >
-              <EuiContextMenu initialPanelId={0} panels={getVizContextPanels(closeVizPopover)} />
-            </EuiPopover>
-          </EuiFlexItem>
-        )}
+        <EuiFlexItem grow={false}>{addButton}</EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="xxl" />
     </div>

--- a/dashboards-observability/public/components/custom_panels/panel_modules/empty_panel.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/empty_panel.tsx
@@ -4,7 +4,8 @@
  */
 
 import { EuiSpacer, EuiText, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import React from 'react';
+import React, { useState } from 'react';
+import { AddVisualizationPopover } from '../helpers/add_visualization_popover';
 
 /*
  * EmptyPanelView - This Sub-component is shown to the user when a operational panel is empty
@@ -15,10 +16,16 @@ import React from 'react';
  */
 
 interface EmptyPanelViewProps {
-  addButton: any;
+  addButton?: any;
+  addVizDisabled: boolean;
+  showFlyout: (isReplacement?: boolean, replaceVizId?: string) => void;
 }
 
-export const EmptyPanelView = ({ addButton }: EmptyPanelViewProps) => {
+export const EmptyPanelView = ({
+  addVizDisabled,
+  showFlyout,
+  addButton = <AddVisualizationPopover addVizDisabled={addVizDisabled} showFlyout={showFlyout} />,
+}: EmptyPanelViewProps) => {
   return (
     <div>
       <EuiSpacer size="xxl" />

--- a/dashboards-observability/public/components/custom_panels/panel_modules/panel_grid/__tests__/__snapshots__/panel_grid.test.tsx.snap
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/panel_grid/__tests__/__snapshots__/panel_grid.test.tsx.snap
@@ -50,6 +50,7 @@ exports[`Panel Grid Component renders panel grid component with empty visualizat
   editMode={false}
   endTime="now"
   http={[MockFunction]}
+  onEditClick={[Function]}
   onRefresh={false}
   panelId=""
   panelVisualizations={Array []}

--- a/dashboards-observability/public/components/custom_panels/panel_modules/panel_grid/__tests__/panel_grid.test.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/panel_grid/__tests__/panel_grid.test.tsx
@@ -31,6 +31,9 @@ describe('Panel Grid Component', () => {
     const pplFilterValue = '';
     const showFlyout = jest.fn();
     const editActionType = '';
+    const onEditClick = (savedVisId: string) => {
+      window.location.assign(`#/event_analytics/explorer/${savedVisId}`);
+    };
 
     const wrapper = mount(
       <PanelGrid
@@ -48,6 +51,7 @@ describe('Panel Grid Component', () => {
         pplFilterValue={pplFilterValue}
         showFlyout={showFlyout}
         editActionType={editActionType}
+        onEditClick={onEditClick}
       />
     );
     wrapper.update();

--- a/dashboards-observability/public/components/custom_panels/panel_modules/panel_grid/panel_grid.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/panel_grid/panel_grid.tsx
@@ -38,7 +38,7 @@ const ResponsiveGridLayout = WidthProvider(Responsive);
  * editActionType: Type of action done while clicking the edit button
  */
 
-type Props = {
+interface PanelGridProps {
   http: CoreStart['http'];
   chrome: CoreStart['chrome'];
   panelId: string;
@@ -48,34 +48,33 @@ type Props = {
   pplService: PPLService;
   startTime: string;
   endTime: string;
-  fromApp?: boolean;
-  switchToEditViz?: any;
+  onEditClick: (savedVisualizationId: string) => any;
   onRefresh: boolean;
   cloneVisualization: (visualzationTitle: string, savedVisualizationId: string) => void;
   pplFilterValue: string;
   showFlyout: (isReplacement?: boolean | undefined, replaceVizId?: string | undefined) => void;
   editActionType: string;
   setEditVizId?: any;
-};
+}
 
-export const PanelGrid = ({
-  http,
-  chrome,
-  panelId,
-  panelVisualizations,
-  setPanelVisualizations,
-  editMode,
-  pplService,
-  startTime,
-  endTime,
-  fromApp = false,
-  switchToEditViz,
-  onRefresh,
-  cloneVisualization,
-  pplFilterValue,
-  showFlyout,
-  editActionType,
-}: Props) => {
+export const PanelGrid = (props: PanelGridProps) => {
+  const {
+    http,
+    chrome,
+    panelId,
+    panelVisualizations,
+    setPanelVisualizations,
+    editMode,
+    pplService,
+    startTime,
+    endTime,
+    onEditClick,
+    onRefresh,
+    cloneVisualization,
+    pplFilterValue,
+    showFlyout,
+    editActionType,
+  } = props;
   const [currentLayout, setCurrentLayout] = useState<Layout[]>([]);
   const [postEditLayout, setPostEditLayout] = useState<Layout[]>([]);
   const [gridData, setGridData] = useState(panelVisualizations.map(() => <></>));
@@ -100,8 +99,7 @@ export const PanelGrid = ({
           fromTime={startTime}
           toTime={endTime}
           onRefresh={onRefresh}
-          fromApp={fromApp}
-          switchToEditViz={switchToEditViz}
+          onEditClick={onEditClick}
           cloneVisualization={cloneVisualization}
           pplFilterValue={pplFilterValue}
           showFlyout={showFlyout}

--- a/dashboards-observability/public/components/custom_panels/panel_modules/visualization_container/__tests__/visualization_container.test.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/visualization_container/__tests__/visualization_container.test.tsx
@@ -39,6 +39,9 @@ describe.skip('Visualization Container Component', () => {
     const showFlyout = jest.fn();
     const removeVisualization = jest.fn();
     const pplService = new PPLService(httpClientMock);
+    const onEditClick = (savedVisId: string) => {
+      window.location.assign(`#/event_analytics/explorer/${savedVisId}`);
+    };
 
     const wrapper = mount(
       <VisualizationContainer
@@ -54,6 +57,7 @@ describe.skip('Visualization Container Component', () => {
         pplFilterValue={pplFilterValue}
         showFlyout={showFlyout}
         removeVisualization={removeVisualization}
+        onEditClick={onEditClick}
       />
     );
     wrapper.update();

--- a/dashboards-observability/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/visualization_container/visualization_container.tsx
@@ -53,8 +53,7 @@ interface Props {
   onRefresh: boolean;
   pplFilterValue: string;
   usedInNotebooks?: boolean;
-  fromApp?: boolean;
-  switchToEditViz?: any;
+  onEditClick: (savedVisualizationId: string) => any;
   cloneVisualization?: (visualzationTitle: string, savedVisualizationId: string) => void;
   showFlyout?: (isReplacement?: boolean | undefined, replaceVizId?: string | undefined) => void;
   removeVisualization?: (visualizationId: string) => void;
@@ -71,8 +70,7 @@ export const VisualizationContainer = ({
   onRefresh,
   pplFilterValue,
   usedInNotebooks,
-  fromApp,
-  switchToEditViz,
+  onEditClick,
   cloneVisualization,
   showFlyout,
   removeVisualization,
@@ -94,11 +92,7 @@ export const VisualizationContainer = ({
       disabled={disablePopover}
       onClick={() => {
         closeActionsMenu();
-        if (fromApp) {
-          switchToEditViz(savedVisualizationId);
-        } else {
-          window.location.assign(`#/event_analytics/explorer/${savedVisualizationId}`);
-        }
+        onEditClick(savedVisualizationId);
       }}
     >
       Edit

--- a/dashboards-observability/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/__snapshots__/visualization_flyout.test.tsx.snap
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/__snapshots__/visualization_flyout.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
 <VisaulizationFlyout
-  appPanel={false}
   closeFlyout={[MockFunction]}
   end="now"
   http={[MockFunction]}
@@ -1062,7 +1061,6 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
 
 exports[`Visualization Flyout Component renders replace visualization Flyout 1`] = `
 <VisaulizationFlyout
-  appPanel={false}
   closeFlyout={[MockFunction]}
   end="2011-08-12T01:23:45.678Z"
   http={[MockFunction]}

--- a/dashboards-observability/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/__snapshots__/visualization_flyout.test.tsx.snap
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/__snapshots__/visualization_flyout.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
           <h2
             id="addVisualizationFlyout"
           >
-            Select Existing Visualization
+            Select existing visualization
           </h2>
         </EuiTitle>
       </EuiFlyoutHeader>
@@ -239,7 +239,7 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                                   class="euiTitle euiTitle--medium"
                                   id="addVisualizationFlyout"
                                 >
-                                  Select Existing Visualization
+                                  Select existing visualization
                                 </h2>
                               </div>
                               <div
@@ -376,7 +376,7 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                                     class="euiTitle euiTitle--medium"
                                     id="addVisualizationFlyout"
                                   >
-                                    Select Existing Visualization
+                                    Select existing visualization
                                   </h2>
                                 </div>
                                 <div
@@ -513,7 +513,7 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                                       class="euiTitle euiTitle--medium"
                                       id="addVisualizationFlyout"
                                     >
-                                      Select Existing Visualization
+                                      Select existing visualization
                                     </h2>
                                   </div>
                                   <div
@@ -638,7 +638,7 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                                         class="euiTitle euiTitle--medium"
                                         id="addVisualizationFlyout"
                                       >
-                                        Select Existing Visualization
+                                        Select existing visualization
                                       </h2>
                                     </div>
                                     <div
@@ -816,7 +816,7 @@ exports[`Visualization Flyout Component renders add visualization Flyout 1`] = `
                                     className="euiTitle euiTitle--medium"
                                     id="addVisualizationFlyout"
                                   >
-                                    Select Existing Visualization
+                                    Select existing visualization
                                   </h2>
                                 </EuiTitle>
                               </div>
@@ -1138,7 +1138,7 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
           <h2
             id="addVisualizationFlyout"
           >
-            Replace Visualization
+            Replace visualization
           </h2>
         </EuiTitle>
       </EuiFlyoutHeader>
@@ -1303,7 +1303,7 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                                   class="euiTitle euiTitle--medium"
                                   id="addVisualizationFlyout"
                                 >
-                                  Replace Visualization
+                                  Replace visualization
                                 </h2>
                               </div>
                               <div
@@ -1444,7 +1444,7 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                                     class="euiTitle euiTitle--medium"
                                     id="addVisualizationFlyout"
                                   >
-                                    Replace Visualization
+                                    Replace visualization
                                   </h2>
                                 </div>
                                 <div
@@ -1585,7 +1585,7 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                                       class="euiTitle euiTitle--medium"
                                       id="addVisualizationFlyout"
                                     >
-                                      Replace Visualization
+                                      Replace visualization
                                     </h2>
                                   </div>
                                   <div
@@ -1714,7 +1714,7 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                                         class="euiTitle euiTitle--medium"
                                         id="addVisualizationFlyout"
                                       >
-                                        Replace Visualization
+                                        Replace visualization
                                       </h2>
                                     </div>
                                     <div
@@ -1896,7 +1896,7 @@ exports[`Visualization Flyout Component renders replace visualization Flyout 1`]
                                     className="euiTitle euiTitle--medium"
                                     id="addVisualizationFlyout"
                                   >
-                                    Replace Visualization
+                                    Replace visualization
                                   </h2>
                                 </EuiTitle>
                               </div>

--- a/dashboards-observability/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/visualization_flyout.test.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/visualization_flyout/__tests__/visualization_flyout.test.tsx
@@ -37,7 +37,6 @@ describe('Visualization Flyout Component', () => {
         http={httpClientMock}
         pplService={pplService}
         isFlyoutReplacement={isFlyoutReplacement}
-        appPanel={false}
       />
     );
 
@@ -69,7 +68,6 @@ describe('Visualization Flyout Component', () => {
         pplService={pplService}
         isFlyoutReplacement={isFlyoutReplacement}
         replaceVisualizationId={replaceVisualizationId}
-        appPanel={false}
       />
     );
 

--- a/dashboards-observability/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
@@ -75,14 +75,12 @@ interface VisualizationFlyoutProps {
   setPanelVisualizations: React.Dispatch<React.SetStateAction<VisualizationType[]>>;
   isFlyoutReplacement?: boolean | undefined;
   replaceVisualizationId?: string | undefined;
-  appPanel: boolean;
   appId?: string;
 }
 
 export const VisaulizationFlyout = ({
   panelId,
-  appId,
-  appPanel,
+  appId = '',
   pplFilterValue,
   closeFlyout,
   start,
@@ -293,7 +291,7 @@ export const VisaulizationFlyout = ({
         if (res.visualizations.length > 0) {
           setSavedVisualizations(res.visualizations);
           const filterAppVis = res.visualizations.filter((vis: SavedVisualizationType) => {
-            return appPanel
+            return appId
               ? vis.hasOwnProperty('application_id')
                 ? vis.application_id === appId
                 : false

--- a/dashboards-observability/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
@@ -213,7 +213,7 @@ export const VisaulizationFlyout = ({
     <EuiFlyoutHeader hasBorder>
       <EuiTitle size="m">
         <h2 id="addVisualizationFlyout">
-          {isFlyoutReplacement ? 'Replace Visualization' : 'Select Existing Visualization'}
+          {isFlyoutReplacement ? 'Replace visualization' : 'Select existing visualization'}
         </h2>
       </EuiTitle>
     </EuiFlyoutHeader>

--- a/dashboards-observability/public/components/notebooks/components/paragraph_components/para_output.tsx
+++ b/dashboards-observability/public/components/notebooks/components/paragraph_components/para_output.tsx
@@ -133,6 +133,9 @@ export const ParaOutput = (props: {
           let toObs = moment(visInput?.timeRange?.to).format(dateFormat);
           fromObs = fromObs === 'Invalid date' ? visInput.timeRange.from : fromObs;
           toObs = toObs === 'Invalid date' ? visInput.timeRange.to : toObs;
+          const onEditClick = (savedVisualizationId: string) => {
+            window.location.assign(`#/event_analytics/explorer/${savedVisualizationId}`);
+          };
           return (
             <>
               <EuiText size="s" style={{ marginLeft: 9 }}>
@@ -143,6 +146,7 @@ export const ParaOutput = (props: {
                   http={props.http}
                   editMode={false}
                   visualizationId={''}
+                  onEditClick={onEditClick}
                   savedVisualizationId={para.visSavedObjId}
                   pplService={props.pplService}
                   fromTime={para.visStartTime}


### PR DESCRIPTION
### Description
- Clean up breadcrumbs
- Remove switchToEditViz becuase it is called in home
- Add onEditClick prop that takes the function to call when edit visualization is clicked
- Make add visualization popover a component
- Change button text to sentence case for event analytics to match rest of Observability
- Add cypress tests to check
  - App panels don't show up in Operational Panels table
  - App visualizations don't show up in Event Analytics table
  - App visualizations don't show up in add existing visualization flyout in Operational Panels
  - Show all visualizations of this application in availability configuration
  - Empty panel view has working add button in Operational Panels
  - Empty panel view has working add button in App Analytics

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
