### PR TITLE
Adding legacy UI route for traces

### DIFF
--- a/dashboards-observability/public/components/trace_analytics/components/common/legacy_route_helpers.ts
+++ b/dashboards-observability/public/components/trace_analytics/components/common/legacy_route_helpers.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { observabilityID } from "../../../../../common/constants/shared";
+
+export const convertLegacyTraceAnalyticsUrl = (location: Location)=> {
+  const pathname = location.pathname.replace('trace-analytics-dashboards', observabilityID);
+  const hash = `#/trace_analytics${location.hash.replace(/^#/, '/home')}${
+    location.hash.includes('?') ? location.search.replace(/^\?/, '&') : location.search
+  }`;
+  return pathname + hash;
+};

--- a/dashboards-observability/public/plugin.ts
+++ b/dashboards-observability/public/plugin.ts
@@ -15,6 +15,7 @@ import TimestampUtils from './services/timestamp/timestamp';
 import SavedObjects from './services/saved_objects/event_analytics/saved_objects';
 import { AppPluginStartDependencies, ObservabilitySetup, ObservabilityStart } from './types';
 import { convertLegacyNotebooksUrl } from './components/notebooks/components/helpers/legacy_route_helpers';
+import { convertLegacyTraceAnalyticsUrl } from './components/trace_analytics/components/common/legacy_route_helpers';
 import { uiSettingsService } from '../common/utils';
 
 export class ObservabilityPlugin implements Plugin<ObservabilitySetup, ObservabilityStart> {
@@ -24,6 +25,11 @@ export class ObservabilityPlugin implements Plugin<ObservabilitySetup, Observabi
     // redirect legacy notebooks URL to current URL under observability
     if (window.location.pathname.includes('notebooks-dashboards')) {
       window.location.assign(convertLegacyNotebooksUrl(window.location));
+    }
+
+    // redirect legacy trace analytics URL to current URL under observability
+    if (window.location.pathname.includes('trace-analytics-dashboards')) {
+      window.location.assign(convertLegacyTraceAnalyticsUrl(window.location));
     }
 
     core.application.register({


### PR DESCRIPTION
Signed-off-by: Shenoy Pratik <sgguruda@amazon.com>

### Description
Fixes the old trace analytics link, redirects to the current trace home inside observability. 

### Issues Resolved
#281 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
