### PR TITLE
Change 2.0-alpha1 to 2.0-rc1.

### DIFF
--- a/opensearch-observability/build.gradle
+++ b/opensearch-observability/build.gradle
@@ -10,9 +10,9 @@ import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
 buildscript {
     ext {
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        opensearch_version = System.getProperty("opensearch.version", "2.0.0-alpha1-SNAPSHOT")
-        buildVersionQualifier = System.getProperty("build.version_qualifier", "alpha1")
-        // 2.0.0-alpha1-SNAPSHOT -> 2.0.0.0-alpha1-SNAPSHOT
+        opensearch_version = System.getProperty("opensearch.version", "2.0.0-rc1-SNAPSHOT")
+        buildVersionQualifier = System.getProperty("build.version_qualifier", "rc1")
+        // 2.0.0-rc1-SNAPSHOT -> 2.0.0.0-rc1-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'
         if (buildVersionQualifier) {


### PR DESCRIPTION
Following https://github.com/opensearch-project/opensearch-build/pull/1863, change 2.0-alpha1 to 2.0-rc1.