### PR TITLE
Fix change availability bug

### DIFF
--- a/dashboards-observability/public/components/application_analytics/home.tsx
+++ b/dashboards-observability/public/components/application_analytics/home.tsx
@@ -200,7 +200,9 @@ export const Home = (props: HomeProps) => {
       .get(`${APP_ANALYTICS_API_PREFIX}/`)
       .then(async (res) => {
         // Want to calculate availability going down the table
+        const mainVisIdStore: Record<string, string> = {};
         for (let i = 0; i < res.data.length; i++) {
+          mainVisIdStore[res.data[i].id] = res.data[i].availability.mainVisId;
           res.data[i].availability = { name: 'loading', color: '', mainVisId: '' };
         }
         setApplicationList(res.data);
@@ -209,7 +211,7 @@ export const Home = (props: HomeProps) => {
             http,
             pplService,
             res.data[i],
-            res.data[i].availability.mainVisId,
+            mainVisIdStore[res.data[i].id],
             () => {}
           );
           // Need to set state with new object to trigger re-render


### PR DESCRIPTION
Signed-off-by: Eugene Lee <eugenesk@amazon.com>

### Description
MainVisId is saved when first fetched before all availability is set to loading before calculating.

### Issues Resolved
Changing availability was not working in the app table

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
