### PR TITLE
Fix test to check for empty event analytics

### DIFF
--- a/dashboards-observability/.cypress/integration/app_analytics.spec.js
+++ b/dashboards-observability/.cypress/integration/app_analytics.spec.js
@@ -22,6 +22,8 @@ import {
   trace_one,
   trace_two,
   trace_three,
+  query_one,
+  query_two,
   visOneName,
   visTwoName,
   composition,
@@ -348,7 +350,7 @@ describe('Viewing application', () => {
     cy.get('.aa-List').find('.aa-Item').should('have.length', 11);
     cy.get('[data-test-subj="searchAutocompleteTextArea"]').focus().type('x', {delay: TYPING_DELAY});
     cy.focused().clear();
-    cy.get('[data-test-subj="searchAutocompleteTextArea"]').focus().type('where DestCityName = "Venice" | stats count() by span( timestamp , 6h )', {delay: TYPING_DELAY});
+    cy.get('[data-test-subj="searchAutocompleteTextArea"]').focus().type(query_one, {delay: TYPING_DELAY});
     changeTimeTo24('months');
     cy.wait(delay * 2);
     cy.get('.euiTab').contains('Visualizations').click();
@@ -412,7 +414,7 @@ describe('Viewing application', () => {
     cy.get('[data-test-subj="searchAutocompleteTextArea"]').clear();
     cy.get('[data-test-subj="searchAutocompleteTextArea"]').focus().type('x', {delay: TYPING_DELAY});
     cy.focused().clear();
-    cy.get('[data-test-subj="searchAutocompleteTextArea"]').focus().type('where DestCityName = "Venice" | stats count() by span( timestamp , 6h )', {delay: TYPING_DELAY});
+    cy.get('[data-test-subj="searchAutocompleteTextArea"]').focus().type(query_two, {delay: TYPING_DELAY});
     cy.get('.euiButton').contains('Refresh').click();
     cy.wait(delay);
     cy.get('.euiTab').contains('Visualizations').click();
@@ -481,30 +483,30 @@ describe('Viewing application', () => {
   it('Hides application visualizations in Event Analytics', () => {
     cy.visit(`${Cypress.env('opensearchDashboards')}/app/observability-dashboards#/event_analytics`);
     cy.wait(delay*3);
-    if (cy.get('.euiFieldSearch').length > 1) {
+    if (cy.get('.euiButton').length == 2) {
       cy.get('input.euiFieldSearch').type(visOneName, {delay: TYPING_DELAY});
-    cy.wait(delay);
-    cy.get('.euiTableCellContent__text').contains('No items found').should('exist');
-    cy.get('input.euiFieldSearch').clear().type(visTwoName, {delay: TYPING_DELAY});
-    cy.wait(delay);
-    cy.get('.euiTableCellContent__text').contains('No items found').should('exist');
-    cy.get('.euiFormControlLayoutClearButton').click();
-    cy.wait(delay);
-    cy.get('[data-test-subj="tablePaginationPopoverButton"]').click();
-    cy.get('.euiContextMenuItem__text').contains('50 rows').click();
-    cy.get('.euiCheckbox__input[data-test-subj="checkboxSelectAll"]').click();
-    cy.wait(delay);
-    cy.get('.euiButton__text').contains('Actions').click();
-    cy.wait(delay);
-    cy.get('.euiContextMenuItem__text').contains('Delete').click();
-    cy.wait(delay);
+      cy.wait(delay);
+      cy.get('.euiTableCellContent__text').contains('No items found').should('exist');
+      cy.get('input.euiFieldSearch').clear().type(visTwoName, {delay: TYPING_DELAY});
+      cy.wait(delay);
+      cy.get('.euiTableCellContent__text').contains('No items found').should('exist');
+      cy.get('.euiFormControlLayoutClearButton').click();
+      cy.wait(delay);
+      cy.get('[data-test-subj="tablePaginationPopoverButton"]').click();
+      cy.get('.euiContextMenuItem__text').contains('50 rows').click();
+      cy.get('.euiCheckbox__input[data-test-subj="checkboxSelectAll"]').click();
+      cy.wait(delay);
+      cy.get('.euiButton__text').contains('Actions').click();
+      cy.wait(delay);
+      cy.get('.euiContextMenuItem__text').contains('Delete').click();
+      cy.wait(delay);
 
-    cy.get('button.euiButton--danger').should('be.disabled');
+      cy.get('button.euiButton--danger').should('be.disabled');
 
-    cy.get('input.euiFieldText[placeholder="delete"]').type('delete');
-    cy.get('button.euiButton--danger').should('not.be.disabled');
-    cy.get('.euiButton__text').contains('Delete').click();
-    cy.wait(delay);
+      cy.get('input.euiFieldText[placeholder="delete"]').type('delete');
+      cy.get('button.euiButton--danger').should('not.be.disabled');
+      cy.get('.euiButton__text').contains('Delete').click();
+      cy.wait(delay);
     }
   });
 

--- a/dashboards-observability/.cypress/utils/app_constants.js
+++ b/dashboards-observability/.cypress/utils/app_constants.js
@@ -81,12 +81,8 @@ export const service_two = 'payment';
 export const trace_one = 'HTTP POST';
 export const trace_two = 'HTTP GET';
 export const trace_three = 'client_pay_order';
-export const spanQueryOnePartOne = 'where DestCityName ';
-export const spanQueryOnePartTwo = '= "Venice" | stats count() by span( timestamp ';
-export const spanQueryOnePartThree = ', 6h )';
-export const spanQueryTwoPartOne = 'where OriginCityName ';
-export const spanQueryTwoPartTwo = '= "Seoul" | stats count() by span( timestamp ';
-export const spanQueryTwoPartThree = ', 6h )';
+export const query_one = 'where DestCityName = "Venice" | stats count() by span( timestamp , 6h )';
+export const query_two = 'where OriginCityName = "Seoul" | stats count() by span( timestamp , 6h )';
 export const visOneName = 'Flights to Venice';
 export const visTwoName = 'Flights from Seoul';
 export const composition = 'order, payment, HTTP POST, HTTP GET, client_pay_order'


### PR DESCRIPTION
- Change test constants to have one full query
- Fix test for application visualizations showing up in event analytics to make sure it is not already empty

Signed-off-by: Eugene Lee <eugenesk@amazon.com>

### Description
[Describe what this change achieves]

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
