### PR TITLE
[OSD][Tests] add test subject to app title for app analytics

### DIFF
--- a/dashboards-observability/.cypress/integration/app_analytics.spec.js
+++ b/dashboards-observability/.cypress/integration/app_analytics.spec.js
@@ -205,7 +205,7 @@ describe('Viewing application', () => {
   it('Has working breadcrumbs', () => {
     cy.get('.euiBreadcrumb').contains('Cypress').click();
     cy.wait(delay);
-    cy.get('.euiTitle').contains(nameOne).should('exist');
+    cy.get('[data-test-subj="appAnalyticsAppName"]').contains(nameOne).should('exist');
     cy.get('.euiBreadcrumb').contains('Application analytics').click();
     cy.wait(delay);
     cy.get('.euiTitle').contains('Applications').should('exist');

--- a/dashboards-observability/public/components/application_analytics/components/application.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/application.tsx
@@ -503,7 +503,7 @@ export function Application(props: AppDetailProps) {
           <EuiPageHeader>
             <EuiPageHeaderSection>
               <EuiTitle size="l">
-                <h1>{application.name}</h1>
+                <h1 data-test-subj={'appAnalyticsAppName'}>{application.name}</h1>
               </EuiTitle>
               <EuiText>
                 <p>{application.description}</p>


### PR DESCRIPTION
### Description
Using a test subject we can find the specific element instead
of trying to search the DOM for the class and hope the class
is the right class that contains the element we are looking for.

We can search the dom for this specific test subject and actually
make the test runner wait until this test subject exists before
executing the tests.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>

### Related Issue
https://github.com/opensearch-project/observability/issues/679

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
