### PR TITLE
Update availabilityVizId if visualization is removed from panel

### DIFF
--- a/dashboards-observability/public/components/application_analytics/components/application.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/application.tsx
@@ -24,10 +24,10 @@ import PPLService from 'public/services/requests/ppl';
 import SavedObjects from 'public/services/saved_objects/event_analytics/saved_objects';
 import TimestampUtils from 'public/services/timestamp/timestamp';
 import React, { ReactChild, useEffect, useState } from 'react';
-import { uniqueId } from 'lodash';
 import { useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { last } from 'lodash';
+import { VisualizationType } from 'common/types/custom_panels';
 import { TracesContent } from '../../../components/trace_analytics/components/traces/traces_content';
 import { DashboardContent } from '../../../components/trace_analytics/components/dashboard/dashboard_content';
 import { ServicesContent } from '../../trace_analytics/components/services/services_content';
@@ -382,6 +382,12 @@ export function Application(props: AppDetailProps) {
     switchToEditViz(savedVisualizationId);
   };
 
+  const updateAvailabilityVizId = (vizs: VisualizationType[]) => {
+    if (!vizs.map((viz) => viz.savedVisualizationId).includes(application.availabilityVisId)) {
+      updateApp(appId, { availabilityVisId: '' }, 'editAvailability');
+    }
+  };
+
   const getPanel = () => {
     return (
       <CustomPanelView
@@ -399,6 +405,7 @@ export function Application(props: AppDetailProps) {
         setToast={setToasts}
         page="app"
         appId={appId}
+        updateAvailabilityVizId={updateAvailabilityVizId}
         startTime={appStartTime}
         endTime={appEndTime}
         setStartTime={setStartTimeForApp}

--- a/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
+++ b/dashboards-observability/public/components/custom_panels/custom_panel_view.tsx
@@ -109,6 +109,7 @@ interface CustomPanelViewProps {
   setEndTime: any;
   childBreadcrumbs?: EuiBreadcrumb[];
   appId?: string;
+  updateAvailabilityVizId?: any;
   onAddClick?: any;
 }
 
@@ -127,6 +128,7 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
     endTime,
     setStartTime,
     setEndTime,
+    updateAvailabilityVizId,
     renameCustomPanel,
     deleteCustomPanel,
     cloneCustomPanel,
@@ -643,6 +645,7 @@ export const CustomPanelView = (props: CustomPanelViewProps) => {
             <PanelGrid
               http={http}
               panelId={panelId}
+              updateAvailabilityVizId={updateAvailabilityVizId}
               chrome={chrome}
               panelVisualizations={panelVisualizations}
               setPanelVisualizations={setPanelVisualizations}

--- a/dashboards-observability/public/components/custom_panels/panel_modules/panel_grid/panel_grid.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/panel_grid/panel_grid.tsx
@@ -44,6 +44,7 @@ interface PanelGridProps {
   http: CoreStart['http'];
   chrome: CoreStart['chrome'];
   panelId: string;
+  updateAvailabilityVizId?: any;
   panelVisualizations: VisualizationType[];
   setPanelVisualizations: React.Dispatch<React.SetStateAction<VisualizationType[]>>;
   editMode: boolean;
@@ -64,6 +65,7 @@ export const PanelGrid = (props: PanelGridProps) => {
     http,
     chrome,
     panelId,
+    updateAvailabilityVizId,
     panelVisualizations,
     setPanelVisualizations,
     editMode,
@@ -166,6 +168,7 @@ export const PanelGrid = (props: PanelGridProps) => {
         _.omit(layout, ['static', 'moved'])
       );
       saveVisualizationLayouts(panelId, visualizationParams);
+      updateAvailabilityVizId(panelVisualizations);
     }
   }, [editActionType]);
 


### PR DESCRIPTION
Signed-off-by: Eugene Lee <eugenesk@amazon.com>

### Description
Update availability viz id to empty if the visualization it was set to gets removed from the panel

### Issues Resolved
Bug where if the selected visualization for availability was removed from the panel, availability got stuck as undefined

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
