### PR TITLE
Feature/error toast on invalid valueoption selection 666

### DIFF
--- a/dashboards-observability/.cypress/integration/1_event_analytics.spec.js
+++ b/dashboards-observability/.cypress/integration/1_event_analytics.spec.js
@@ -616,3 +616,47 @@ describe('Renders data view', () => {
     cy.get('[data-test-subj="workspace__dataTable"]').should('not.exist');
   });
 });
+
+describe('Renders chart and verify Toast message if X-axis and Y-axis values are empty', () => {
+  beforeEach(() => {
+    landOnEventVisualizations();
+  });
+
+  it('Renders chart, clear X-axis and Y-axis value and click on Apply button, Toast message should display with error message', () => {
+    querySearch(TEST_QUERIES[4].query, TEST_QUERIES[4].dateRangeDOM);
+    cy.get('[data-test-subj="configPane__vizTypeSelector"] [data-test-subj="comboBoxInput"]')
+      .type('Bar')
+      .type('{enter}');
+    cy.wait(delay);
+    cy.get('#configPanel__value_options [data-test-subj="comboBoxClearButton"]').eq(0).click({force:true});
+    cy.get('#configPanel__value_options [data-test-subj="comboBoxToggleListButton"]').eq(0).click();
+    cy.wait(delay)
+    cy.get('#configPanel__value_options [data-test-subj="comboBoxClearButton"]').click({multiple:true});
+    cy.get('#configPanel__value_options [data-test-subj="comboBoxToggleListButton"]').eq(1).click();
+    cy.get('#configPanel__value_options [data-test-subj="comboBoxInput"]').eq(0).should('have.value', '');
+    cy.get('#configPanel__value_options [data-test-subj="comboBoxInput"]').eq(1).should('have.value', '');
+    cy.get('[data-test-subj="visualizeEditorRenderButton"]').click();
+    cy.get('[data-test-subj="euiToastHeader"]').contains('Invalid value options configuration selected.').should('exist');
+  });
+
+  it('Renders chart, clear X-axis and Y-axis value and try to save visulization, Toast message should display with error message', () => {
+    querySearch(TEST_QUERIES[4].query, TEST_QUERIES[4].dateRangeDOM);
+    cy.get('[data-test-subj="configPane__vizTypeSelector"] [data-test-subj="comboBoxInput"]')
+      .type('Bar')
+      .type('{enter}');
+    cy.wait(delay);
+    cy.get('#configPanel__value_options [data-test-subj="comboBoxClearButton"]').eq(0).click({force:true});
+    cy.get('#configPanel__value_options [data-test-subj="comboBoxToggleListButton"]').eq(0).click();
+    cy.wait(delay)
+    cy.get('#configPanel__value_options [data-test-subj="comboBoxClearButton"]').click({multiple:true});
+    cy.get('#configPanel__value_options [data-test-subj="comboBoxInput"]').eq(0).should('have.value', '');
+    cy.get('#configPanel__value_options [data-test-subj="comboBoxInput"]').eq(1).should('have.value', '');
+    cy.get('[data-test-subj="eventExplorer__saveManagementPopover"]').click();
+    cy.get('[data-test-subj="eventExplorer__querySaveComboBox"]').click();
+    cy.get('.euiComboBoxOptionsList__rowWrap .euiFilterSelectItem').eq(0).click();
+    cy.get('.euiPopover__panel .euiFormControlLayoutIcons [data-test-subj="comboBoxToggleListButton"]').eq(0).click();
+    cy.get('.euiPopover__panel input').eq(1).type(`Test visulization_`);
+    cy.get('[data-test-subj="eventExplorer__querySaveConfirm"]').click();
+    cy.get('[data-test-subj="euiToastHeader"]').contains('Invalid value options configuration selected.').should('exist');
+  });
+});

--- a/dashboards-observability/common/constants/explorer.ts
+++ b/dashboards-observability/common/constants/explorer.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { visChartTypes } from "./shared";
 export const EVENT_ANALYTICS_DOCUMENTATION_URL =
   'https://opensearch.org/docs/latest/observability-plugin/event-analytics/';
 export const OPEN_TELEMETRY_LOG_CORRELATION_LINK =
@@ -77,3 +78,5 @@ export const REDUX_EXPL_SLICE_COUNT_DISTRIBUTION = 'countDistributionVisualizati
 export const PLOTLY_GAUGE_COLUMN_NUMBER = 5;
 export const APP_ANALYTICS_TAB_ID_REGEX = /application-analytics-tab.+/;
 export const DEFAULT_AVAILABILITY_QUERY = 'stats count() by span( timestamp, 1h )';
+
+export const VIZ_CONTAIN_XY_AXIS = [visChartTypes.Bar, visChartTypes.Histogram, visChartTypes.Line, visChartTypes.Pie];

--- a/dashboards-observability/common/constants/shared.ts
+++ b/dashboards-observability/common/constants/shared.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { IField } from '../../common/types/explorer';
 import CSS from 'csstype';
 
 // Client route
@@ -71,9 +72,32 @@ export const pageStyles: CSS.Properties = {
   maxWidth: '1130px',
 };
 
+
+export enum visChartTypes {
+  Bar = 'bar',
+  HorizontalBar = 'horizontal_bar',
+  Line = 'line',
+  Pie = 'pie',
+  HeatMap = 'heatmap',
+  Text = 'text',
+  Gauge = 'gauge',
+  Histogram = 'histogram',
+  TreeMap = 'tree_map'
+}
+
+export interface ValueOptionsAxes {
+  xaxis ?: IField[];
+  yaxis ?: IField[];
+  zaxis ?: IField[];
+  childField?: IField[];
+  valueField?: IField[];
+  series?: IField[];
+  value?: IField[];
+}
+
 export const NUMERICAL_FIELDS = ['short', 'integer', 'long', 'float', 'double'];
 
-export const ENABLED_VIS_TYPES = ['bar', 'horizontal_bar', 'line', 'pie', 'heatmap', 'text'];
+export const ENABLED_VIS_TYPES = [visChartTypes.Bar, visChartTypes.HorizontalBar, visChartTypes.Line, visChartTypes.Pie, visChartTypes.HeatMap, visChartTypes.Text];
 
 //Live tail constants
 export const LIVE_OPTIONS = [

--- a/dashboards-observability/common/types/explorer.ts
+++ b/dashboards-observability/common/types/explorer.ts
@@ -31,6 +31,7 @@ export interface IQueryTab {
 export interface IField {
   name: string;
   type: string;
+  label?: string;
 }
 
 export interface ITabQueryResults {

--- a/dashboards-observability/public/components/custom_panels/helpers/__tests__/__snapshots__/utils.test.tsx.snap
+++ b/dashboards-observability/public/components/custom_panels/helpers/__tests__/__snapshots__/utils.test.tsx.snap
@@ -10,12 +10,14 @@ exports[`Utils helper functions renders displayVisualization function 1`] = `
           "defaultAxes": Object {
             "xaxis": Array [
               Object {
+                "label": "Carrier",
                 "name": "Carrier",
                 "type": "keyword",
               },
             ],
             "yaxis": Array [
               Object {
+                "label": "avg(FlightDelayMin)",
                 "name": "avg(FlightDelayMin)",
                 "type": "double",
               },
@@ -224,12 +226,14 @@ exports[`Utils helper functions renders displayVisualization function 1`] = `
             "defaultAxes": Object {
               "xaxis": Array [
                 Object {
+                  "label": "Carrier",
                   "name": "Carrier",
                   "type": "keyword",
                 },
               ],
               "yaxis": Array [
                 Object {
+                  "label": "avg(FlightDelayMin)",
                   "name": "avg(FlightDelayMin)",
                   "type": "double",
                 },
@@ -461,12 +465,14 @@ exports[`Utils helper functions renders displayVisualization function 1`] = `
               "defaultAxes": Object {
                 "xaxis": Array [
                   Object {
+                    "label": "Carrier",
                     "name": "Carrier",
                     "type": "keyword",
                   },
                 ],
                 "yaxis": Array [
                   Object {
+                    "label": "avg(FlightDelayMin)",
                     "name": "avg(FlightDelayMin)",
                     "type": "double",
                   },
@@ -853,12 +859,14 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
           "defaultAxes": Object {
             "xaxis": Array [
               Object {
+                "label": "Carrier",
                 "name": "Carrier",
                 "type": "keyword",
               },
             ],
             "yaxis": Array [
               Object {
+                "label": "avg(FlightDelayMin)",
                 "name": "avg(FlightDelayMin)",
                 "type": "double",
               },
@@ -1084,12 +1092,14 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
             "defaultAxes": Object {
               "xaxis": Array [
                 Object {
+                  "label": "Carrier",
                   "name": "Carrier",
                   "type": "keyword",
                 },
               ],
               "yaxis": Array [
                 Object {
+                  "label": "avg(FlightDelayMin)",
                   "name": "avg(FlightDelayMin)",
                   "type": "double",
                 },
@@ -1369,12 +1379,14 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
               "defaultAxes": Object {
                 "xaxis": Array [
                   Object {
+                    "label": "Carrier",
                     "name": "Carrier",
                     "type": "keyword",
                   },
                 ],
                 "yaxis": Array [
                   Object {
+                    "label": "avg(FlightDelayMin)",
                     "name": "avg(FlightDelayMin)",
                     "type": "double",
                   },
@@ -1788,12 +1800,14 @@ exports[`Utils helper functions renders displayVisualization function 3`] = `
           "defaultAxes": Object {
             "xaxis": Array [
               Object {
+                "label": "Carrier",
                 "name": "Carrier",
                 "type": "keyword",
               },
             ],
             "yaxis": Array [
               Object {
+                "label": "avg(FlightDelayMin)",
                 "name": "avg(FlightDelayMin)",
                 "type": "double",
               },
@@ -1996,12 +2010,14 @@ exports[`Utils helper functions renders displayVisualization function 3`] = `
             "defaultAxes": Object {
               "xaxis": Array [
                 Object {
+                  "label": "Carrier",
                   "name": "Carrier",
                   "type": "keyword",
                 },
               ],
               "yaxis": Array [
                 Object {
+                  "label": "avg(FlightDelayMin)",
                   "name": "avg(FlightDelayMin)",
                   "type": "double",
                 },
@@ -2227,12 +2243,14 @@ exports[`Utils helper functions renders displayVisualization function 3`] = `
               "defaultAxes": Object {
                 "xaxis": Array [
                   Object {
+                    "label": "Carrier",
                     "name": "Carrier",
                     "type": "keyword",
                   },
                 ],
                 "yaxis": Array [
                   Object {
+                    "label": "avg(FlightDelayMin)",
                     "name": "avg(FlightDelayMin)",
                     "type": "double",
                   },
@@ -2613,12 +2631,14 @@ exports[`Utils helper functions renders displayVisualization function 4`] = `
           "defaultAxes": Object {
             "xaxis": Array [
               Object {
+                "label": "span(timestamp,1h)",
                 "name": "span(timestamp,1h)",
                 "type": "timestamp",
               },
             ],
             "yaxis": Array [
               Object {
+                "label": "count('ip')",
                 "name": "count('ip')",
                 "type": "integer",
               },
@@ -2794,12 +2814,14 @@ exports[`Utils helper functions renders displayVisualization function 4`] = `
             "defaultAxes": Object {
               "xaxis": Array [
                 Object {
+                  "label": "span(timestamp,1h)",
                   "name": "span(timestamp,1h)",
                   "type": "timestamp",
                 },
               ],
               "yaxis": Array [
                 Object {
+                  "label": "count('ip')",
                   "name": "count('ip')",
                   "type": "integer",
                 },
@@ -2998,12 +3020,14 @@ exports[`Utils helper functions renders displayVisualization function 4`] = `
               "defaultAxes": Object {
                 "xaxis": Array [
                   Object {
+                    "label": "span(timestamp,1h)",
                     "name": "span(timestamp,1h)",
                     "type": "timestamp",
                   },
                 ],
                 "yaxis": Array [
                   Object {
+                    "label": "count('ip')",
                     "name": "count('ip')",
                     "type": "integer",
                   },

--- a/dashboards-observability/public/components/event_analytics/explorer/explorer.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/explorer.tsx
@@ -141,6 +141,7 @@ export const Explorer = ({
   const [browserTabFocus, setBrowserTabFocus] = useState(true);
   const [liveTimestamp, setLiveTimestamp] = useState(DATE_PICKER_FORMAT);
   const [triggerAvailability, setTriggerAvailability] = useState(false);
+  const [isValidDataConfigOptionSelected, setIsValidDataConfigOptionSelected] = useState<Boolean>(false);
 
   const queryRef = useRef();
   const appBasedRef = useRef('');
@@ -727,6 +728,9 @@ export const Explorer = ({
     }
   };
 
+  const changeIsValidConfigOptionState = (isValidConfig: Boolean) =>
+  setIsValidDataConfigOptionSelected(isValidConfig);
+
   const getExplorerVis = () => {
     return (
       <ExplorerVisualizations
@@ -741,6 +745,7 @@ export const Explorer = ({
         visualizations={visualizations}
         handleOverrideTimestamp={handleOverrideTimestamp}
         callback={callbackForConfig}
+        changeIsValidConfigOptionState={changeIsValidConfigOptionState}
       />
     );
   };
@@ -833,6 +838,10 @@ export const Explorer = ({
     if (isEmpty(selectedPanelNameRef.current)) {
       setIsPanelTextFieldInvalid(true);
       setToast('Name field cannot be empty.', 'danger');
+      return;
+    }
+    if (!isValidDataConfigOptionSelected) {
+      setToast('Invalid value options configuration selected.', 'danger');
       return;
     }
     setIsPanelTextFieldInvalid(false);

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/__tests__/__snapshots__/config_panel.test.tsx.snap
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/__tests__/__snapshots__/config_panel.test.tsx.snap
@@ -2,6 +2,21 @@
 
 exports[`Config panel component Renders config panel with visualization data 1`] = `
 <ConfigPanel
+  changeIsValidConfigOptionState={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          true,
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
   setCurVisId={[MockFunction]}
   visualizations={
     Object {
@@ -2541,6 +2556,11 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                           },
                         }
                       }
+                      vizState={
+                        Object {
+                          "valueOptions": Object {},
+                        }
+                      }
                     />,
                     "id": "data-panel",
                     "name": "Data",
@@ -2960,6 +2980,11 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                                 },
                               },
                             },
+                          }
+                        }
+                        vizState={
+                          Object {
+                            "valueOptions": Object {},
                           }
                         }
                       />,
@@ -3828,6 +3853,11 @@ exports[`Config panel component Renders config panel with visualization data 1`]
                               },
                             },
                           },
+                        }
+                      }
+                      vizState={
+                        Object {
+                          "valueOptions": Object {},
                         }
                       }
                     >

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/__tests__/config_panel.test.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/__tests__/config_panel.test.tsx
@@ -26,6 +26,7 @@ describe('Config panel component', () => {
     const tabId = 'query-panel-1';
     const curVisId = 'bar';
     const pplService = new PPLService(httpClientMock);
+    const mockChangeIsValidConfigOptionState = jest.fn();
     
     const wrapper = mount(
       <TabContext.Provider
@@ -39,7 +40,7 @@ describe('Config panel component', () => {
           pplService: pplService,
         }}
       >
-        <ConfigPanel visualizations={TEST_VISUALIZATIONS_DATA} setCurVisId={setCurVisId} />
+        <ConfigPanel visualizations={TEST_VISUALIZATIONS_DATA} setCurVisId={setCurVisId} changeIsValidConfigOptionState={mockChangeIsValidConfigOptionState} />
       </TabContext.Provider>
     );
 

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panel.tsx
@@ -26,6 +26,7 @@ import { TabContext } from '../../../hooks';
 import { DefaultEditorControls } from './config_panel_footer';
 import { getVisType } from '../../../../visualizations/charts/vis_types';
 import { ENABLED_VIS_TYPES, ValueOptionsAxes, visChartTypes } from '../../../../../../common/constants/shared';
+import { VIZ_CONTAIN_XY_AXIS } from '../../../../../../common/constants/explorer';
 
 const CONFIG_LAYOUT_TEMPLATE = `
 {
@@ -112,8 +113,8 @@ export const ConfigPanel = ({ visualizations, setCurVisId, callback, changeIsVal
    // To check, If user empty any of the value options
    const isValidValueOptionConfigSelected = useMemo(() => {
     const valueOptions = vizConfigs.dataConfig?.valueOptions;
-    const { Bar, Line, Histogram, Pie, TreeMap, Gauge, HeatMap } = visChartTypes;
-    const isValidValueOptionsXYAxes = [Bar, Line, Histogram, Pie].includes(curVisId) &&
+    const { TreeMap, Gauge, HeatMap } = visChartTypes;
+    const isValidValueOptionsXYAxes = VIZ_CONTAIN_XY_AXIS.includes(curVisId) &&
       valueOptions?.xaxis?.length !== 0 && valueOptions?.yaxis?.length !== 0;
 
     const isValid_valueOptions: { [key: string]: boolean } = {

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panel.tsx
@@ -25,7 +25,7 @@ import { getDefaultSpec } from '../visualization_specs/default_spec';
 import { TabContext } from '../../../hooks';
 import { DefaultEditorControls } from './config_panel_footer';
 import { getVisType } from '../../../../visualizations/charts/vis_types';
-import { ENABLED_VIS_TYPES } from '../../../../../../common/constants/shared';
+import { ENABLED_VIS_TYPES, ValueOptionsAxes, visChartTypes } from '../../../../../../common/constants/shared';
 
 const CONFIG_LAYOUT_TEMPLATE = `
 {
@@ -60,13 +60,26 @@ interface PanelTabType {
   content?: any;
 }
 
-export const ConfigPanel = ({ visualizations, setCurVisId, callback }: any) => {
+export const ConfigPanel = ({ visualizations, setCurVisId, callback, changeIsValidConfigOptionState  }: any) => {
   const { tabId, curVisId, dispatch, changeVisualizationConfig, setToast } = useContext<any>(
     TabContext
   );
   const { data, vis } = visualizations;
   const { userConfigs } = data;
 
+  const getDefaultAxisSelected = () => {
+    let chartBasedAxes: ValueOptionsAxes = {};
+    const [valueField] = data.defaultAxes?.yaxis ?? [];
+    if (curVisId === visChartTypes.TreeMap) {
+      chartBasedAxes["childField"] = data.defaultAxes.xaxis ?? [];
+      chartBasedAxes["valueField"] = [valueField];
+    } else {
+      chartBasedAxes = { ...data.defaultAxes };
+    }
+    return {
+      valueOptions: { ...(chartBasedAxes && chartBasedAxes) }
+    }
+  }
   const [vizConfigs, setVizConfigs] = useState({
     dataConfig: {},
     layoutConfig: userConfigs?.layoutConfig
@@ -78,6 +91,7 @@ export const ConfigPanel = ({ visualizations, setCurVisId, callback }: any) => {
   useEffect(() => {
     setVizConfigs({
       ...userConfigs,
+      dataConfig: { ...vizConfigs.dataConfig, ...(userConfigs?.dataConfig ? userConfigs.dataConfig : getDefaultAxisSelected()) },
       layoutConfig: userConfigs?.layoutConfig
         ? hjson.stringify({ ...userConfigs.layoutConfig }, HJSON_STRINGIFY_OPTIONS)
         : getDefaultSpec(),
@@ -95,8 +109,34 @@ export const ConfigPanel = ({ visualizations, setCurVisId, callback }: any) => {
     []
   );
 
+   // To check, If user empty any of the value options
+   const isValidValueOptionConfigSelected = useMemo(() => {
+    const valueOptions = vizConfigs.dataConfig?.valueOptions;
+    const { Bar, Line, Histogram, Pie, TreeMap, Gauge, HeatMap } = visChartTypes;
+    const isValidValueOptionsXYAxes = [Bar, Line, Histogram, Pie].includes(curVisId) &&
+      valueOptions?.xaxis?.length !== 0 && valueOptions?.yaxis?.length !== 0;
+
+    const isValid_valueOptions: { [key: string]: boolean } = {
+      tree_map: curVisId === TreeMap && valueOptions?.childField?.length !== 0 &&
+        valueOptions?.valueField?.length !== 0,
+      gauge: Boolean(curVisId === Gauge && valueOptions?.series && valueOptions.series?.length !== 0 &&
+        valueOptions?.value && valueOptions.value?.length !== 0),
+      heatmap: Boolean(curVisId === HeatMap && valueOptions?.zaxis && valueOptions.zaxis?.length !== 0),
+      bar: isValidValueOptionsXYAxes,
+      line: isValidValueOptionsXYAxes,
+      histogram: isValidValueOptionsXYAxes,
+      pie: isValidValueOptionsXYAxes
+    }
+    return isValid_valueOptions[curVisId];
+  }, [vizConfigs.dataConfig]);
+
+  useEffect(() => changeIsValidConfigOptionState(Boolean(isValidValueOptionConfigSelected)), [isValidValueOptionConfigSelected]);
+
   const handleConfigUpdate = useCallback(() => {
     try {
+      if (!isValidValueOptionConfigSelected) {
+        setToast(`Invalid value options configuration selected.`, 'danger');
+      }
       dispatch(
         changeVisualizationConfig({
           tabId,

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/index.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/index.tsx
@@ -27,6 +27,7 @@ interface IExplorerVisualizationsProps {
   visualizations: IVisualizationContainerProps;
   handleOverrideTimestamp: (field: IField) => void;
   callback?: any;
+  changeIsValidConfigOptionState: (isValidConfigOptionSelected: Boolean) => void;
 }
 
 export const ExplorerVisualizations = ({
@@ -41,6 +42,7 @@ export const ExplorerVisualizations = ({
   visualizations,
   handleOverrideTimestamp,
   callback,
+  changeIsValidConfigOptionState
 }: IExplorerVisualizationsProps) => {
   return (
     <EuiResizableContainer>
@@ -76,6 +78,7 @@ export const ExplorerVisualizations = ({
               curVisId={curVisId}
               setCurVisId={setCurVisId}
               callback={callback}
+              changeIsValidConfigOptionState={changeIsValidConfigOptionState}
             />
           </EuiResizablePanel>
         </>

--- a/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
+++ b/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
@@ -20,11 +20,12 @@ interface IVizContainerProps {
   };
 }
 
-const getDefaultXYAxisLabels = (vizFields: string[]) => {
+const getDefaultXYAxisLabels = (vizFields: IField[]) => {
   if (isEmpty(vizFields)) return {};
+  const vizFieldsWithLabel = vizFields.map(vizField => ({ ...vizField, label: vizField.name }));
   return {
-    xaxis: [vizFields[vizFields.length - 1]] || [],
-    yaxis: take(vizFields, vizFields.length - 1 > 0 ? vizFields.length - 1 : 1) || [],
+    xaxis: [vizFieldsWithLabel[vizFieldsWithLabel.length - 1]] || [],
+    yaxis: take(vizFieldsWithLabel, vizFieldsWithLabel.length - 1 > 0 ? vizFieldsWithLabel.length - 1 : 1) || [],
   };
 };
 


### PR DESCRIPTION
### Description
[Describe what this change achieves]

The below features are implemented in these changes:

- Default axes selected on Data config value options
- Error toast If the user selected any invalid or empty axis
- Error toast if the user trying to save the visualization, If f user selected any invalid or empty axis

Added these features for existing as well as new charts including Gauge, Histogram, and Treemap.

### Issues Resolved
[List any issues this PR will resolve]
#666 

### Check List
- [x]  New functionality includes an Error toast message on invalid value options selection while Apply and Save click, snapshot test cases, cypress test cases.
  - [ ] All tests pass, including unit test, and integration test, except a few test cases are failing at my end which are not related to this functionality.
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
