### PR TITLE
[BUG]: Scatter chart "Dimensions" takes a field even if the ppl query don't have a timestamp in it.

### DIFF
--- a/dashboards-observability/public/components/custom_panels/helpers/__tests__/__snapshots__/utils.test.tsx.snap
+++ b/dashboards-observability/public/components/custom_panels/helpers/__tests__/__snapshots__/utils.test.tsx.snap
@@ -1512,8 +1512,6 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
               Object {
                 "label": "",
                 "name": "",
-                "side": "left",
-                "type": "",
               },
             ],
             "yaxis": Array [
@@ -1639,34 +1637,7 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
             "size": 4,
             "status": 200,
           },
-          "userConfigs": Object {
-            "dataConfig": Object {
-              "valueOptions": Object {
-                "dimensions": Array [
-                  Object {
-                    "aggregation": "",
-                    "custom_label": "",
-                    "label": "",
-                    "name": "",
-                    "side": "left",
-                    "type": "",
-                  },
-                ],
-                "metrics": Array [
-                  Object {
-                    "label": "avg(FlightDelayMin)",
-                    "name": "avg(FlightDelayMin)",
-                    "type": "double",
-                  },
-                  Object {
-                    "label": "Carrier",
-                    "name": "Carrier",
-                    "type": "keyword",
-                  },
-                ],
-              },
-            },
-          },
+          "userConfigs": Object {},
         },
         "vis": Object {
           "category": "Visualizations",
@@ -2047,8 +2018,6 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
                 Object {
                   "label": "",
                   "name": "",
-                  "side": "left",
-                  "type": "",
                 },
               ],
               "yaxis": Array [
@@ -2174,34 +2143,7 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
               "size": 4,
               "status": 200,
             },
-            "userConfigs": Object {
-              "dataConfig": Object {
-                "valueOptions": Object {
-                  "dimensions": Array [
-                    Object {
-                      "aggregation": "",
-                      "custom_label": "",
-                      "label": "",
-                      "name": "",
-                      "side": "left",
-                      "type": "",
-                    },
-                  ],
-                  "metrics": Array [
-                    Object {
-                      "label": "avg(FlightDelayMin)",
-                      "name": "avg(FlightDelayMin)",
-                      "type": "double",
-                    },
-                    Object {
-                      "label": "Carrier",
-                      "name": "Carrier",
-                      "type": "keyword",
-                    },
-                  ],
-                },
-              },
-            },
+            "userConfigs": Object {},
           },
           "vis": Object {
             "category": "Visualizations",
@@ -2636,8 +2578,6 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
                   Object {
                     "label": "",
                     "name": "",
-                    "side": "left",
-                    "type": "",
                   },
                 ],
                 "yaxis": Array [
@@ -2763,34 +2703,7 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
                 "size": 4,
                 "status": 200,
               },
-              "userConfigs": Object {
-                "dataConfig": Object {
-                  "valueOptions": Object {
-                    "dimensions": Array [
-                      Object {
-                        "aggregation": "",
-                        "custom_label": "",
-                        "label": "",
-                        "name": "",
-                        "side": "left",
-                        "type": "",
-                      },
-                    ],
-                    "metrics": Array [
-                      Object {
-                        "label": "avg(FlightDelayMin)",
-                        "name": "avg(FlightDelayMin)",
-                        "type": "double",
-                      },
-                      Object {
-                        "label": "Carrier",
-                        "name": "Carrier",
-                        "type": "keyword",
-                      },
-                    ],
-                  },
-                },
-              },
+              "userConfigs": Object {},
             },
             "vis": Object {
               "category": "Visualizations",

--- a/dashboards-observability/public/components/custom_panels/helpers/__tests__/__snapshots__/utils.test.tsx.snap
+++ b/dashboards-observability/public/components/custom_panels/helpers/__tests__/__snapshots__/utils.test.tsx.snap
@@ -1512,6 +1512,8 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
               Object {
                 "label": "",
                 "name": "",
+                "side": "left",
+                "type": "",
               },
             ],
             "yaxis": Array [
@@ -1637,7 +1639,34 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
             "size": 4,
             "status": 200,
           },
-          "userConfigs": Object {},
+          "userConfigs": Object {
+            "dataConfig": Object {
+              "valueOptions": Object {
+                "dimensions": Array [
+                  Object {
+                    "aggregation": "",
+                    "custom_label": "",
+                    "label": "",
+                    "name": "",
+                    "side": "left",
+                    "type": "",
+                  },
+                ],
+                "metrics": Array [
+                  Object {
+                    "label": "avg(FlightDelayMin)",
+                    "name": "avg(FlightDelayMin)",
+                    "type": "double",
+                  },
+                  Object {
+                    "label": "Carrier",
+                    "name": "Carrier",
+                    "type": "keyword",
+                  },
+                ],
+              },
+            },
+          },
         },
         "vis": Object {
           "category": "Visualizations",
@@ -2018,6 +2047,8 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
                 Object {
                   "label": "",
                   "name": "",
+                  "side": "left",
+                  "type": "",
                 },
               ],
               "yaxis": Array [
@@ -2143,7 +2174,34 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
               "size": 4,
               "status": 200,
             },
-            "userConfigs": Object {},
+            "userConfigs": Object {
+              "dataConfig": Object {
+                "valueOptions": Object {
+                  "dimensions": Array [
+                    Object {
+                      "aggregation": "",
+                      "custom_label": "",
+                      "label": "",
+                      "name": "",
+                      "side": "left",
+                      "type": "",
+                    },
+                  ],
+                  "metrics": Array [
+                    Object {
+                      "label": "avg(FlightDelayMin)",
+                      "name": "avg(FlightDelayMin)",
+                      "type": "double",
+                    },
+                    Object {
+                      "label": "Carrier",
+                      "name": "Carrier",
+                      "type": "keyword",
+                    },
+                  ],
+                },
+              },
+            },
           },
           "vis": Object {
             "category": "Visualizations",
@@ -2578,6 +2636,8 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
                   Object {
                     "label": "",
                     "name": "",
+                    "side": "left",
+                    "type": "",
                   },
                 ],
                 "yaxis": Array [
@@ -2703,7 +2763,34 @@ exports[`Utils helper functions renders displayVisualization function 2`] = `
                 "size": 4,
                 "status": 200,
               },
-              "userConfigs": Object {},
+              "userConfigs": Object {
+                "dataConfig": Object {
+                  "valueOptions": Object {
+                    "dimensions": Array [
+                      Object {
+                        "aggregation": "",
+                        "custom_label": "",
+                        "label": "",
+                        "name": "",
+                        "side": "left",
+                        "type": "",
+                      },
+                    ],
+                    "metrics": Array [
+                      Object {
+                        "label": "avg(FlightDelayMin)",
+                        "name": "avg(FlightDelayMin)",
+                        "type": "double",
+                      },
+                      Object {
+                        "label": "Carrier",
+                        "name": "Carrier",
+                        "type": "keyword",
+                      },
+                    ],
+                  },
+                },
+              },
             },
             "vis": Object {
               "category": "Visualizations",
@@ -3306,26 +3393,6 @@ exports[`Utils helper functions renders displayVisualization function 3`] = `
                 "sections": Array [
                   Object {
                     "editor": [Function],
-                    "id": "value_options",
-                    "mapTo": "valueOptions",
-                    "name": "Value options",
-                    "schemas": Array [
-                      Object {
-                        "component": null,
-                        "isSingleSelection": false,
-                        "mapTo": "xaxis",
-                        "name": "X-axis",
-                      },
-                      Object {
-                        "component": null,
-                        "isSingleSelection": false,
-                        "mapTo": "yaxis",
-                        "name": "Y-axis",
-                      },
-                    ],
-                  },
-                  Object {
-                    "editor": [Function],
                     "id": "chart_options",
                     "mapTo": "chartOptions",
                     "name": "Chart options",
@@ -3574,26 +3641,6 @@ exports[`Utils helper functions renders displayVisualization function 3`] = `
                   "mapTo": "dataConfig",
                   "name": "Style",
                   "sections": Array [
-                    Object {
-                      "editor": [Function],
-                      "id": "value_options",
-                      "mapTo": "valueOptions",
-                      "name": "Value options",
-                      "schemas": Array [
-                        Object {
-                          "component": null,
-                          "isSingleSelection": false,
-                          "mapTo": "xaxis",
-                          "name": "X-axis",
-                        },
-                        Object {
-                          "component": null,
-                          "isSingleSelection": false,
-                          "mapTo": "yaxis",
-                          "name": "Y-axis",
-                        },
-                      ],
-                    },
                     Object {
                       "editor": [Function],
                       "id": "chart_options",
@@ -3867,26 +3914,6 @@ exports[`Utils helper functions renders displayVisualization function 3`] = `
                     "mapTo": "dataConfig",
                     "name": "Style",
                     "sections": Array [
-                      Object {
-                        "editor": [Function],
-                        "id": "value_options",
-                        "mapTo": "valueOptions",
-                        "name": "Value options",
-                        "schemas": Array [
-                          Object {
-                            "component": null,
-                            "isSingleSelection": false,
-                            "mapTo": "xaxis",
-                            "name": "X-axis",
-                          },
-                          Object {
-                            "component": null,
-                            "isSingleSelection": false,
-                            "mapTo": "yaxis",
-                            "name": "Y-axis",
-                          },
-                        ],
-                      },
                       Object {
                         "editor": [Function],
                         "id": "chart_options",
@@ -4167,26 +4194,6 @@ exports[`Utils helper functions renders displayVisualization function 4`] = `
                 "sections": Array [
                   Object {
                     "editor": [Function],
-                    "id": "value_options",
-                    "mapTo": "valueOptions",
-                    "name": "Value options",
-                    "schemas": Array [
-                      Object {
-                        "component": null,
-                        "isSingleSelection": false,
-                        "mapTo": "xaxis",
-                        "name": "X-axis",
-                      },
-                      Object {
-                        "component": null,
-                        "isSingleSelection": false,
-                        "mapTo": "yaxis",
-                        "name": "Y-axis",
-                      },
-                    ],
-                  },
-                  Object {
-                    "editor": [Function],
                     "id": "chart_options",
                     "mapTo": "chartOptions",
                     "name": "Chart options",
@@ -4381,26 +4388,6 @@ exports[`Utils helper functions renders displayVisualization function 4`] = `
                   "mapTo": "dataConfig",
                   "name": "Style",
                   "sections": Array [
-                    Object {
-                      "editor": [Function],
-                      "id": "value_options",
-                      "mapTo": "valueOptions",
-                      "name": "Value options",
-                      "schemas": Array [
-                        Object {
-                          "component": null,
-                          "isSingleSelection": false,
-                          "mapTo": "xaxis",
-                          "name": "X-axis",
-                        },
-                        Object {
-                          "component": null,
-                          "isSingleSelection": false,
-                          "mapTo": "yaxis",
-                          "name": "Y-axis",
-                        },
-                      ],
-                    },
                     Object {
                       "editor": [Function],
                       "id": "chart_options",
@@ -4620,26 +4607,6 @@ exports[`Utils helper functions renders displayVisualization function 4`] = `
                     "mapTo": "dataConfig",
                     "name": "Style",
                     "sections": Array [
-                      Object {
-                        "editor": [Function],
-                        "id": "value_options",
-                        "mapTo": "valueOptions",
-                        "name": "Value options",
-                        "schemas": Array [
-                          Object {
-                            "component": null,
-                            "isSingleSelection": false,
-                            "mapTo": "xaxis",
-                            "name": "X-axis",
-                          },
-                          Object {
-                            "component": null,
-                            "isSingleSelection": false,
-                            "mapTo": "yaxis",
-                            "name": "Y-axis",
-                          },
-                        ],
-                      },
                       Object {
                         "editor": [Function],
                         "id": "chart_options",

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panel.scss
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panel.scss
@@ -136,3 +136,8 @@ $vis-editor-sidebar-min-width: 350px;
   height: 1198px;
   overflow: auto;
 }
+
+.dimensionTitle {
+  display: inline;
+  margin-right: 5px;
+}

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_item.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_item.tsx
@@ -18,6 +18,7 @@ import {
   EuiText,
   EuiFieldNumber,
   htmlIdGenerator,
+  EuiIconTip,
 } from '@elastic/eui';
 import { useDispatch, batch } from 'react-redux';
 import { changeQuery } from '../../../../../redux/slices/query_slice';
@@ -34,18 +35,23 @@ import { ConfigList } from '../../../../../../../../common/types/explorer';
 import { TabContext } from '../../../../../hooks';
 import { QueryManager } from '../../../../../../../../common/query_manager';
 import { composeAggregations } from '../../../../../../../../common/query_manager/utils';
+import '../../config_panel.scss';
 
 const initialDimensionEntry = {
   label: '',
   name: '',
 };
 
-const initialMetricEntry = {
-  alias: '',
-  label: '',
-  name: '',
-  aggregation: 'count',
-};
+  const { data: vizData = {}, metadata: { fields = [] } = {} } = data?.rawVizData;
+
+  const initialConfigEntry = {
+    label: '',
+    aggregation: '',
+    custom_label: '',
+    name: '',
+    side: 'right',
+    type: '',
+  };
 
 export const DataConfigPanelItem = ({ fieldOptionList, visualizations }: any) => {
   const dispatch = useDispatch();
@@ -163,7 +169,8 @@ export const DataConfigPanelItem = ({ fieldOptionList, visualizations }: any) =>
     const unselectedFields = fieldOptionList.filter((field) => !selectedFields[field.label]);
     return sectionName === 'metrics'
       ? unselectedFields
-      : visualizations.vis.name === visChartTypes.Line
+      : visualizations.vis.name === visChartTypes.Line ||
+        visualizations.vis.name === visChartTypes.Scatter
       ? unselectedFields.filter((i) => i.type === 'timestamp')
       : unselectedFields;
   };
@@ -285,7 +292,9 @@ export const DataConfigPanelItem = ({ fieldOptionList, visualizations }: any) =>
               color="primary"
               onClick={() => handleServiceAdd(sectionName)}
               disabled={
-                sectionName === 'dimensions' && visualizations.vis.name === visChartTypes.Line
+                sectionName === 'dimensions' &&
+                      (visualizations.vis.name === visChartTypes.Line ||
+                        visualizations.vis.name === visChartTypes.Scatter)
               }
             >
               Add
@@ -451,7 +460,11 @@ export const DataConfigPanelItem = ({ fieldOptionList, visualizations }: any) =>
           <EuiTitle size="xxs">
             <h3>Dimensions</h3>
           </EuiTitle>
-          <EuiSpacer size="s" />
+          {fields.find((x) => x.type !== 'timestamp') &&
+            (visualizations.vis.name === visChartTypes.Line ||
+              visualizations.vis.name === visChartTypes.Scatter) && (
+              <EuiIconTip content={tooltipText} position="right" />
+            )}
           {getCommonUI(configList.dimensions, 'dimensions')}
           <EuiSpacer size="s" />
           <EuiTitle size="xxs">

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_item.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_item.tsx
@@ -42,16 +42,14 @@ const initialDimensionEntry = {
   name: '',
 };
 
-  const { data: vizData = {}, metadata: { fields = [] } = {} } = data?.rawVizData;
-
-  const initialConfigEntry = {
-    label: '',
-    aggregation: '',
-    custom_label: '',
-    name: '',
-    side: 'left',
-    type: '',
-  };
+const initialConfigEntry = {
+  label: '',
+  aggregation: '',
+  custom_label: '',
+  name: '',
+  side: 'left',
+  type: '',
+};
 
 export const DataConfigPanelItem = ({ fieldOptionList, visualizations }: any) => {
   const dispatch = useDispatch();
@@ -65,6 +63,9 @@ export const DataConfigPanelItem = ({ fieldOptionList, visualizations }: any) =>
   } = data;
   const [configList, setConfigList] = useState<ConfigList>({});
   const { userConfigs } = data;
+
+  const tooltipText =
+    'You need to have a timestamp field in the PPL query to render this visualization';
 
   useEffect(() => {
     if (userConfigs && userConfigs.dataConfig) {
@@ -293,8 +294,8 @@ export const DataConfigPanelItem = ({ fieldOptionList, visualizations }: any) =>
               onClick={() => handleServiceAdd(sectionName)}
               disabled={
                 sectionName === 'dimensions' &&
-                      (visualizations.vis.name === visChartTypes.Line ||
-                        visualizations.vis.name === visChartTypes.Scatter)
+                (visualizations.vis.name === visChartTypes.Line ||
+                  visualizations.vis.name === visChartTypes.Scatter)
               }
             >
               Add

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_item.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_item.tsx
@@ -49,7 +49,7 @@ const initialDimensionEntry = {
     aggregation: '',
     custom_label: '',
     name: '',
-    side: 'right',
+    side: 'left',
     type: '',
   };
 
@@ -269,7 +269,7 @@ export const DataConfigPanelItem = ({ fieldOptionList, visualizations }: any) =>
                             { id: 'left', label: 'Left' },
                             { id: 'right', label: 'Right' },
                           ]}
-                          idSelected={singleField.side || 'right'}
+                          idSelected={singleField.side || 'left'}
                           handleButtonChange={(id: string) =>
                             updateList(id, index, sectionName, 'side')
                           }
@@ -460,7 +460,7 @@ export const DataConfigPanelItem = ({ fieldOptionList, visualizations }: any) =>
           <EuiTitle size="xxs">
             <h3>Dimensions</h3>
           </EuiTitle>
-          {fields.find((x) => x.type !== 'timestamp') &&
+          {!fields.find((x) => x.type === 'timestamp') &&
             (visualizations.vis.name === visChartTypes.Line ||
               visualizations.vis.name === visChartTypes.Scatter) && (
               <EuiIconTip content={tooltipText} position="right" />

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_item.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_item.tsx
@@ -18,7 +18,7 @@ import {
   EuiText,
   EuiFieldNumber,
   htmlIdGenerator,
-  EuiIconTip,
+  EuiCallOut,
 } from '@elastic/eui';
 import { useDispatch, batch } from 'react-redux';
 import { changeQuery } from '../../../../../redux/slices/query_slice';
@@ -449,6 +449,14 @@ export const DataConfigPanelItem = ({ fieldOptionList, visualizations }: any) =>
         <h3>Data Configurations</h3>
       </EuiTitle>
       <EuiSpacer size="s" />
+      {!fields.find((x) => x.type === 'timestamp') &&
+        (visualizations.vis.name === visChartTypes.Line ||
+          visualizations.vis.name === visChartTypes.Scatter) && (
+          <>
+            <EuiCallOut title={tooltipText} color="warning" iconType="help" />
+            <EuiSpacer size="s" />
+          </>
+        )}
       {visualizations.vis.name !== visChartTypes.Histogram ? (
         <>
           <EuiTitle size="xxs">
@@ -460,11 +468,6 @@ export const DataConfigPanelItem = ({ fieldOptionList, visualizations }: any) =>
           <EuiTitle size="xxs">
             <h3>Dimensions</h3>
           </EuiTitle>
-          {!fields.find((x) => x.type === 'timestamp') &&
-            (visualizations.vis.name === visChartTypes.Line ||
-              visualizations.vis.name === visChartTypes.Scatter) && (
-              <EuiIconTip content={tooltipText} position="right" />
-            )}
           {getCommonUI(configList.dimensions, 'dimensions')}
           <EuiSpacer size="s" />
           <EuiTitle size="xxs">

--- a/dashboards-observability/public/components/visualizations/charts/__tests__/__snapshots__/gauge.test.tsx.snap
+++ b/dashboards-observability/public/components/visualizations/charts/__tests__/__snapshots__/gauge.test.tsx.snap
@@ -384,139 +384,82 @@ exports[`Gauge component Renders gauge component 1`] = `
     }
   }
 >
-  <Plt
-    config={Object {}}
-    data={
-      Array [
-        Object {
-          "domain": Object {
-            "column": 0,
-            "row": 0,
-          },
-          "gauge": Object {},
-          "mode": "gauge+number+delta",
-          "title": Object {
-            "align": "center",
-            "font": Object {
-              "size": 14,
-            },
-            "text": "error, count()",
-          },
-          "type": "indicator",
-          "value": 154,
-        },
-      ]
-    }
-    layout={
-      Object {
-        "colorway": Array [
-          "#8C55A3",
-        ],
-        "grid": Object {
-          "columns": 1,
-          "pattern": "independent",
-          "rows": 1,
-        },
-        "height": 220,
-        "margin": Object {
-          "b": 15,
-          "l": 60,
-          "pad": 0,
-          "r": 10,
-          "t": 30,
-        },
-        "showlegend": true,
-        "title": "",
-      }
-    }
+  <EmptyPlaceholder
+    icon="visGauge"
   >
-    <PlotlyComponent
-      config={
-        Object {
-          "displayModeBar": false,
-        }
-      }
-      data={
-        Array [
-          Object {
-            "domain": Object {
-              "column": 0,
-              "row": 0,
-            },
-            "gauge": Object {},
-            "mode": "gauge+number+delta",
-            "title": Object {
-              "align": "center",
-              "font": Object {
-                "size": 14,
-              },
-              "text": "error, count()",
-            },
-            "type": "indicator",
-            "value": 154,
-          },
-        ]
-      }
-      debug={false}
-      divId="explorerPlotComponent"
-      layout={
-        Object {
-          "autosize": true,
-          "barmode": "stack",
-          "colorway": Array [
-            "#8C55A3",
-          ],
-          "grid": Object {
-            "columns": 1,
-            "pattern": "independent",
-            "rows": 1,
-          },
-          "height": 220,
-          "hovermode": "closest",
-          "legend": Object {
-            "orientation": "h",
-            "traceorder": "normal",
-          },
-          "margin": Object {
-            "b": 15,
-            "l": 60,
-            "pad": 0,
-            "r": 10,
-            "t": 30,
-          },
-          "showlegend": true,
-          "title": "",
-          "xaxis": Object {
-            "automargin": true,
-            "rangemode": "normal",
-            "showgrid": true,
-            "zeroline": false,
-          },
-          "yaxis": Object {
-            "rangemode": "normal",
-            "showgrid": true,
-            "zeroline": false,
-          },
-        }
-      }
-      style={
-        Object {
-          "height": "100%",
-          "width": "100%",
-        }
-      }
-      useResizeHandler={true}
+    <EuiText
+      className="lnsChart__empty"
+      color="subdued"
+      data-test-subj="vizWorkspace__noData"
+      size="xs"
+      textAlign="center"
     >
       <div
-        id="explorerPlotComponent"
-        style={
-          Object {
-            "height": "100%",
-            "width": "100%",
-          }
-        }
-      />
-    </PlotlyComponent>
-  </Plt>
+        className="euiText euiText--extraSmall lnsChart__empty"
+        data-test-subj="vizWorkspace__noData"
+      >
+        <EuiTextAlign
+          textAlign="center"
+        >
+          <div
+            className="euiTextAlign euiTextAlign--center"
+          >
+            <EuiTextColor
+              color="subdued"
+              component="div"
+            >
+              <div
+                className="euiTextColor euiTextColor--subdued"
+              >
+                <EuiIcon
+                  color="subdued"
+                  size="xxl"
+                  type="visGauge"
+                >
+                  <EuiIconEmpty
+                    aria-hidden={true}
+                    className="euiIcon euiIcon--xxLarge euiIcon--subdued euiIcon-isLoading"
+                    focusable="false"
+                    role="img"
+                    style={null}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="euiIcon euiIcon--xxLarge euiIcon--subdued euiIcon-isLoading"
+                      focusable="false"
+                      height={16}
+                      role="img"
+                      style={null}
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                  </EuiIconEmpty>
+                </EuiIcon>
+                <EuiSpacer
+                  size="l"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--l"
+                  />
+                </EuiSpacer>
+                <p>
+                  <FormattedMessage
+                    defaultMessage="No results found"
+                    id="visualization_noData"
+                    values={Object {}}
+                  >
+                    <span>
+                      No results found
+                    </span>
+                  </FormattedMessage>
+                </p>
+              </div>
+            </EuiTextColor>
+          </div>
+        </EuiTextAlign>
+      </div>
+    </EuiText>
+  </EmptyPlaceholder>
 </Gauge>
 `;

--- a/dashboards-observability/public/components/visualizations/charts/__tests__/__snapshots__/pie.test.tsx.snap
+++ b/dashboards-observability/public/components/visualizations/charts/__tests__/__snapshots__/pie.test.tsx.snap
@@ -553,177 +553,82 @@ exports[`Pie component Renders pie component 1`] = `
     }
   }
 >
-  <Plt
-    config={Object {}}
-    data={
-      Array [
-        Object {
-          "automargin": true,
-          "domain": Object {
-            "column": 0,
-            "row": 0,
-          },
-          "hole": 0,
-          "hoverinfo": "all",
-          "labels": Array [
-            "error",
-            "info",
-            "login",
-            "security",
-            "success",
-            "warning",
-          ],
-          "name": "count()",
-          "outsidetextfont": Object {
-            "size": undefined,
-          },
-          "text": "count()",
-          "textinfo": "percent",
-          "textposition": "outside",
-          "type": "pie",
-          "values": Array [
-            154,
-            1753,
-            116,
-            468,
-            1964,
-            219,
-          ],
-        },
-      ]
-    }
-    layout={
-      Object {
-        "colorway": Array [
-          "#8C55A3",
-        ],
-        "grid": Object {
-          "columns": 1,
-          "rows": 1,
-        },
-        "height": 220,
-        "legend": Object {
-          "font": Object {
-            "size": undefined,
-          },
-          "orientation": "v",
-        },
-        "margin": Object {
-          "b": 15,
-          "l": 60,
-          "pad": 0,
-          "r": 10,
-          "t": 30,
-        },
-        "showlegend": "show",
-        "title": "",
-      }
-    }
+  <EmptyPlaceholder
+    icon="visBarVerticalStacked"
   >
-    <PlotlyComponent
-      config={
-        Object {
-          "displayModeBar": false,
-        }
-      }
-      data={
-        Array [
-          Object {
-            "automargin": true,
-            "domain": Object {
-              "column": 0,
-              "row": 0,
-            },
-            "hole": 0,
-            "hoverinfo": "all",
-            "labels": Array [
-              "error",
-              "info",
-              "login",
-              "security",
-              "success",
-              "warning",
-            ],
-            "name": "count()",
-            "outsidetextfont": Object {
-              "size": undefined,
-            },
-            "text": "count()",
-            "textinfo": "percent",
-            "textposition": "outside",
-            "type": "pie",
-            "values": Array [
-              154,
-              1753,
-              116,
-              468,
-              1964,
-              219,
-            ],
-          },
-        ]
-      }
-      debug={false}
-      divId="explorerPlotComponent"
-      layout={
-        Object {
-          "autosize": true,
-          "barmode": "stack",
-          "colorway": Array [
-            "#8C55A3",
-          ],
-          "grid": Object {
-            "columns": 1,
-            "rows": 1,
-          },
-          "height": 220,
-          "hovermode": "closest",
-          "legend": Object {
-            "font": Object {
-              "size": undefined,
-            },
-            "orientation": "v",
-          },
-          "margin": Object {
-            "b": 15,
-            "l": 60,
-            "pad": 0,
-            "r": 10,
-            "t": 30,
-          },
-          "showlegend": "show",
-          "title": "",
-          "xaxis": Object {
-            "automargin": true,
-            "rangemode": "normal",
-            "showgrid": true,
-            "zeroline": false,
-          },
-          "yaxis": Object {
-            "rangemode": "normal",
-            "showgrid": true,
-            "zeroline": false,
-          },
-        }
-      }
-      style={
-        Object {
-          "height": "100%",
-          "width": "100%",
-        }
-      }
-      useResizeHandler={true}
+    <EuiText
+      className="lnsChart__empty"
+      color="subdued"
+      data-test-subj="vizWorkspace__noData"
+      size="xs"
+      textAlign="center"
     >
       <div
-        id="explorerPlotComponent"
-        style={
-          Object {
-            "height": "100%",
-            "width": "100%",
-          }
-        }
-      />
-    </PlotlyComponent>
-  </Plt>
+        className="euiText euiText--extraSmall lnsChart__empty"
+        data-test-subj="vizWorkspace__noData"
+      >
+        <EuiTextAlign
+          textAlign="center"
+        >
+          <div
+            className="euiTextAlign euiTextAlign--center"
+          >
+            <EuiTextColor
+              color="subdued"
+              component="div"
+            >
+              <div
+                className="euiTextColor euiTextColor--subdued"
+              >
+                <EuiIcon
+                  color="subdued"
+                  size="xxl"
+                  type="visBarVerticalStacked"
+                >
+                  <EuiIconEmpty
+                    aria-hidden={true}
+                    className="euiIcon euiIcon--xxLarge euiIcon--subdued euiIcon-isLoading"
+                    focusable="false"
+                    role="img"
+                    style={null}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="euiIcon euiIcon--xxLarge euiIcon--subdued euiIcon-isLoading"
+                      focusable="false"
+                      height={16}
+                      role="img"
+                      style={null}
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                  </EuiIconEmpty>
+                </EuiIcon>
+                <EuiSpacer
+                  size="l"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--l"
+                  />
+                </EuiSpacer>
+                <p>
+                  <FormattedMessage
+                    defaultMessage="No results found"
+                    id="visualization_noData"
+                    values={Object {}}
+                  >
+                    <span>
+                      No results found
+                    </span>
+                  </FormattedMessage>
+                </p>
+              </div>
+            </EuiTextColor>
+          </div>
+        </EuiTextAlign>
+      </div>
+    </EuiText>
+  </EmptyPlaceholder>
 </Pie>
 `;

--- a/dashboards-observability/public/components/visualizations/charts/bar/horizontal_bar_type.ts
+++ b/dashboards-observability/public/components/visualizations/charts/bar/horizontal_bar_type.ts
@@ -35,26 +35,6 @@ export const createHorizontalBarTypeDefinition = (params: BarTypeParams = {}) =>
         editor: VizDataPanel,
         sections: [
           {
-            id: 'value_options',
-            name: 'Value options',
-            editor: ConfigValueOptions,
-            mapTo: 'valueOptions',
-            schemas: [
-              {
-                name: 'X-axis',
-                isSingleSelection: false,
-                component: null,
-                mapTo: 'xaxis',
-              },
-              {
-                name: 'Y-axis',
-                isSingleSelection: false,
-                component: null,
-                mapTo: 'yaxis',
-              },
-            ],
-          },
-          {
             id: 'chart_options',
             name: 'Chart options',
             editor: ConfigValueOptions,

--- a/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
+++ b/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
@@ -50,7 +50,7 @@ const getDefaultXYAxisLabels = (vizFields: IField[], visName: string) => {
 
   const mapXaxis = (): { [key: string]: string }[] => {
     const xaxis = vizFieldsWithLabel.filter((field) => field.type === 'timestamp');
-    return visName === visChartTypes.Line
+    return visName === visChartTypes.Line || visName === visChartTypes.Scatter
       ? xaxis.length === 0
         ? [initialDimensionEntry]
         : xaxis
@@ -58,7 +58,7 @@ const getDefaultXYAxisLabels = (vizFields: IField[], visName: string) => {
   };
 
   const mapYaxis = (): { [key: string]: string }[] =>
-    visName === visChartTypes.Line
+    visName === visChartTypes.Line || visName === visChartTypes.Scatter
       ? vizFieldsWithLabel.filter((field) => field.type !== 'timestamp')
       : take(
           vizFieldsWithLabel,

--- a/dashboards-observability/public/components/visualizations/charts/lines/line.tsx
+++ b/dashboards-observability/public/components/visualizations/charts/lines/line.tsx
@@ -77,18 +77,15 @@ export const Line = ({ visualizations, layout, config }: any) => {
       dataConfig.colorTheme.find((colorSelected) => colorSelected.name.name === field.name)
         ?.color) ||
     PLOTLY_COLOR[index % PLOTLY_COLOR.length];
-  /**
-   * determine x axis
-   */
-  const xaxis = useMemo(() => {
-    // span selection
-    const timestampField = find(fields, (field) => field.type === 'timestamp');
-    if (dataConfig.span && dataConfig.span.time_field && timestampField) {
-      return [timestampField, ...dataConfig.dimensions];
-    }
+  let xaxis;
 
-    return dataConfig.dimensions;
-  }, [dataConfig.dimensions]);
+  const timestampField = find(fields, (field) => field.type === 'timestamp');
+
+  if (dataConfig.span && dataConfig.span.time_field && timestampField) {
+    xaxis = [timestampField, ...dataConfig.dimensions];
+  } else {
+    xaxis = dataConfig.dimensions;
+  }
 
   if (isEmpty(xaxis) || isEmpty(yaxis))
     return <EmptyPlaceholder icon={visualizations?.vis?.icontype} />;

--- a/dashboards-observability/public/components/visualizations/charts/lines/line.tsx
+++ b/dashboards-observability/public/components/visualizations/charts/lines/line.tsx
@@ -137,7 +137,7 @@ export const Line = ({ visualizations, layout, config }: any) => {
             }),
           },
           ...(index > 0 && { overlaying: 'y' }),
-          side: field.side,
+          side: field.side ?? 'left',
         },
       };
 


### PR DESCRIPTION
### Description
Fixed the following 2 issues in this bug:
1. Scatter chart "Dimensions" takes a field even if the ppl query don't have a timestamp in it.
2. Added a warning sign along side dimension when no timestamp field present


### Issues Resolved
#946 #951 

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
