### PR TITLE
Replace Forum link in Observability plugin README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ See [developer guide](DEVELOPER_GUIDE.md) and [how to contribute to this project
 
 If you find a bug, or have a feature request, please don't hesitate to open an issue in this repository.
 
-For more information, see [project website](https://opensearch.org/) and [documentation](https://opensearch.org/docs). If you need help and are unsure where to open an issue, try [forums](https://discuss.opendistrocommunity.dev/).
+For more information, see [project website](https://opensearch.org/) and [documentation](https://opensearch.org/docs). If you need help and are unsure where to open an issue, try the [Forum](https://forum.opensearch.org/c/plugins/observability/49).
 
 ## Code of Conduct
 


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

### Description
Replaced the link to the Forum discussion in the README.md file so that it points to the OpenSearch forum rather than the defunct Open Distro forum.

### Issues Resolved
This fixes the issue for the Observability plugin in [#921](https://github.com/opensearch-project/documentation-website/issues/921).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
