### PR TITLE
[BUG]: UI gets crashed after backspace on time interval value

### DIFF
--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_item.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_item.tsx
@@ -389,12 +389,13 @@ export const DataConfigPanelItem = ({ fieldOptionList, visualizations }: any) =>
                   value={configList.span?.interval ?? 1}
                   min={1}
                   onChange={(e) => {
+                    e.persist();
                     setConfigList((staleState) => {
                       return {
                         ...staleState,
                         span: {
                           ...staleState.span,
-                          interval: e.target.value,
+                          interval: e.target?.value ?? 1,
                         },
                       };
                     });


### PR DESCRIPTION
Signed-off-by: Vishal Kushwah <vishal.kushwah@domo.com>

### Description
Fixed the bug for UI getting blank when the value from interval field is removed with backspace and user starts to type in anything in the box

### Issues Resolved
https://github.com/opensearch-project/observability/issues/1032

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
