### PR TITLE
[FEATURE]: Updated data configuration UI and Two way sync for Custom Label

### DIFF
--- a/dashboards-observability/common/constants/explorer.ts
+++ b/dashboards-observability/common/constants/explorer.ts
@@ -179,6 +179,10 @@ export const DEFAULT_PIE_CHART_PARAMETERS: DefaultPieChartParameterProps = {
 };
 export const GROUPBY = 'dimensions';
 export const AGGREGATIONS = 'series';
+export const PARENTFIELDS = 'parentFields';
+export const VALUEFIELD = 'valueField';
+export const CHILDFIELD = 'childField';
+export const TIMESTAMP = 'timestamp';
 
 // stats constants
 export const STATS_GRID_SPACE_BETWEEN_X_AXIS = 0.01;

--- a/dashboards-observability/common/query_manager/ast/builder/stats_builder.ts
+++ b/dashboards-observability/common/query_manager/ast/builder/stats_builder.ts
@@ -26,6 +26,7 @@ import {
   SpanExpressionChunk,
 } from '../types';
 import { CUSTOM_LABEL } from '../../../../common/constants/explorer';
+
 export class StatsBuilder implements QueryBuilder<Aggregations> {
   constructor(private statsChunk: statsChunk) {}
 

--- a/dashboards-observability/common/query_manager/ast/expression/AggregateTerm.ts
+++ b/dashboards-observability/common/query_manager/ast/expression/AggregateTerm.ts
@@ -2,7 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import { CUSTOM_LABEL } from '../../../../common/constants/explorer';
 import { PPLNode } from '../node';
 import { CUSTOM_LABEL } from '../../../../common/constants/explorer';
 export class AggregateTerm extends PPLNode {

--- a/dashboards-observability/common/query_manager/ast/expression/AggregateTerm.ts
+++ b/dashboards-observability/common/query_manager/ast/expression/AggregateTerm.ts
@@ -4,7 +4,6 @@
  */
 import { CUSTOM_LABEL } from '../../../../common/constants/explorer';
 import { PPLNode } from '../node';
-import { CUSTOM_LABEL } from '../../../../common/constants/explorer';
 export class AggregateTerm extends PPLNode {
   constructor(
     name: string,

--- a/dashboards-observability/common/query_manager/utils/index.ts
+++ b/dashboards-observability/common/query_manager/utils/index.ts
@@ -2,7 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import { CUSTOM_LABEL } from '../../../common/constants/explorer';
 import { AggregationConfigurations, PreviouslyParsedStaleStats } from '../ast/types';
 import { CUSTOM_LABEL } from '../../../common/constants/explorer';
 

--- a/dashboards-observability/common/query_manager/utils/index.ts
+++ b/dashboards-observability/common/query_manager/utils/index.ts
@@ -4,7 +4,6 @@
  */
 import { CUSTOM_LABEL } from '../../../common/constants/explorer';
 import { AggregationConfigurations, PreviouslyParsedStaleStats } from '../ast/types';
-import { CUSTOM_LABEL } from '../../../common/constants/explorer';
 
 export const composeAggregations = (
   aggConfig: AggregationConfigurations,

--- a/dashboards-observability/common/types/explorer.ts
+++ b/dashboards-observability/common/types/explorer.ts
@@ -335,7 +335,8 @@ export interface SelectedConfigItem {
   name: string;
 }
 
-export interface SelectedConfigItem {
-  index: number;
+export interface ParentUnitType {
   name: string;
+  label: string;
+  type: string;
 }

--- a/dashboards-observability/common/types/explorer.ts
+++ b/dashboards-observability/common/types/explorer.ts
@@ -278,7 +278,7 @@ export interface LiveTailProps {
 export interface ConfigListEntry {
   label: string;
   aggregation: string;
-  custom_label: string;
+  alias: string;
   name: string;
   side: string;
   type: string;
@@ -328,4 +328,9 @@ export interface DataConfigPanelProps {
 export interface GetTooltipHoverInfoType {
   tooltipMode: string;
   tooltipText: string;
+}
+
+export interface SelectedConfigItem {
+  index: number;
+  name: string;
 }

--- a/dashboards-observability/common/types/explorer.ts
+++ b/dashboards-observability/common/types/explorer.ts
@@ -6,6 +6,7 @@
 import { History } from 'history';
 import Plotly from 'plotly.js-dist';
 import { QueryManager } from 'common/query_manager';
+import { VIS_CHART_TYPES } from '../../common/constants/shared';
 import {
   RAW_QUERY,
   SELECTED_FIELDS,
@@ -340,4 +341,20 @@ export interface ParentUnitType {
   name: string;
   label: string;
   type: string;
+}
+
+export interface TreemapParentsProps {
+  selectedAxis: ParentUnitType[];
+  setSelectedParentItem: (item: { isClicked: boolean; index: number }) => void;
+  handleUpdateParentFields: (arr: ParentUnitType[]) => void;
+}
+
+export interface DataConfigPanelFieldProps {
+  list: ConfigListEntry[];
+  sectionName: string;
+  visType: VIS_CHART_TYPES;
+  addButtonText: string;
+  handleServiceAdd: (name: string) => void;
+  handleServiceRemove: (index: number, name: string) => void;
+  handleServiceEdit: (isClose: boolean, arrIndex: number, sectionName: string) => void;
 }

--- a/dashboards-observability/common/types/explorer.ts
+++ b/dashboards-observability/common/types/explorer.ts
@@ -18,6 +18,7 @@ import {
   SELECTED_DATE_RANGE,
   GROUPBY,
   AGGREGATIONS,
+  CUSTOM_LABEL,
 } from '../constants/explorer';
 import {
   CoreStart,
@@ -278,7 +279,7 @@ export interface LiveTailProps {
 export interface ConfigListEntry {
   label: string;
   aggregation: string;
-  alias: string;
+  [CUSTOM_LABEL]: string;
   name: string;
   side: string;
   type: string;

--- a/dashboards-observability/common/types/explorer.ts
+++ b/dashboards-observability/common/types/explorer.ts
@@ -334,3 +334,8 @@ export interface SelectedConfigItem {
   index: number;
   name: string;
 }
+
+export interface SelectedConfigItem {
+  index: number;
+  name: string;
+}

--- a/dashboards-observability/public/components/event_analytics/explorer/explorer.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/explorer.tsx
@@ -965,7 +965,7 @@ export const Explorer = ({
           changeVizConfig({
             tabId,
             vizId: curVisId,
-            data: { ...updatedDataConfig },
+            data: { dataConfig: { ...updatedDataConfig } },
           })
         );
       }

--- a/dashboards-observability/public/components/event_analytics/explorer/explorer.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/explorer.tsx
@@ -86,6 +86,7 @@ import {
   statsChunk,
   GroupByChunk,
   StatsAggregationChunk,
+  GroupField,
 } from '../../../../common/query_manager/ast/types';
 
 const TYPE_TAB_MAPPING = {
@@ -315,7 +316,7 @@ export const Explorer = ({
     indexPattern: string
   ): Promise<IDefaultTimestampState> => await timestampUtils.getTimestamp(indexPattern);
 
-  const fetchData = async (startingTime?: string, endingTime?: string) => {
+  const fetchData = async (isRefresh?: boolean, startingTime?: string, endingTime?: string) => {
     const curQuery = queryRef.current;
     const rawQueryStr = buildQuery(appBasedRef.current, curQuery![RAW_QUERY]);
     const curIndex = getIndexPatternFromRawQuery(rawQueryStr);
@@ -374,10 +375,7 @@ export const Explorer = ({
           changeVisualizationConfig({
             tabId,
             vizId: visId,
-            data: {
-              ...userVizConfigs[visId],
-              dataConfig: {},
-            },
+            data: isRefresh ? { dataConfig: {} } : { ...userVizConfigs[visId] },
           })
         );
       }
@@ -931,11 +929,12 @@ export const Explorer = ({
             label: agg.function?.value_expression,
             name: agg.function?.value_expression,
             aggregation: agg.function?.name,
-            [CUSTOM_LABEL]: agg[CUSTOM_LABEL],
+            [CUSTOM_LABEL]: agg[CUSTOM_LABEL as keyof StatsAggregationChunk],
           })),
           [GROUPBY]: groupByToken?.group_fields?.map((agg) => ({
             label: agg.name ?? '',
             name: agg.name ?? '',
+            [CUSTOM_LABEL]: agg[CUSTOM_LABEL as keyof GroupField] ?? '',
           })),
           span,
         };
@@ -955,7 +954,7 @@ export const Explorer = ({
       if (availability !== true) {
         await updateQueryInStore(tempQuery);
       }
-      await fetchData();
+      await fetchData(true);
 
       if (selectedContentTabId === TAB_CHART_ID) {
         // parse stats section on every search
@@ -1268,7 +1267,7 @@ export const Explorer = ({
   const handleLiveTailSearch = useCallback(
     async (startingTime: string, endingTime: string) => {
       await updateQueryInStore(tempQuery);
-      fetchData(startingTime, endingTime);
+      fetchData(false, startingTime, endingTime);
     },
     [tempQuery]
   );

--- a/dashboards-observability/public/components/event_analytics/explorer/explorer.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/explorer.tsx
@@ -155,7 +155,6 @@ export const Explorer = ({
   const [isValidDataConfigOptionSelected, setIsValidDataConfigOptionSelected] = useState<boolean>(
     false
   );
-
   const queryRef = useRef();
   const appBasedRef = useRef('');
   appBasedRef.current = appBaseQuery;

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panel.scss
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panel.scss
@@ -4,7 +4,7 @@
  */
 
 .lnsConfigPanel__addLayerBtn {
-  color: transparentize($euiColorMediumShade, .3);
+  color: transparentize($euiColorMediumShade, 0.3);
   // Remove EuiButton's default shadow to make button more subtle
   // sass-lint:disable-block no-important
   box-shadow: none !important;
@@ -177,7 +177,15 @@ $vis-editor-sidebar-min-width: 350px;
   text-overflow: ellipsis;
   overflow: hidden;
 }
-.panel_section{
-  border-bottom: 1px solid #D3DAE6;
+
+.panel_section {
+  border-bottom: 1px solid #d3dae6;
 }
 
+.panel_title {
+  display: block;
+}
+
+.panel_title:first-letter {
+  text-transform: uppercase;
+}

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panel.scss
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panel.scss
@@ -21,7 +21,7 @@ $vis-editor-sidebar-min-width: 350px;
   min-width: $vis-editor-sidebar-min-width;
 
   // a hack for IE, issue: https://github.com/elastic/kibana/issues/66586
-  > .visEditorSidebar__formWrapper {
+  >.visEditorSidebar__formWrapper {
     flex-basis: auto;
   }
 }
@@ -66,7 +66,7 @@ $vis-editor-sidebar-min-width: 350px;
   padding: $euiSizeS;
   border-radius: $euiBorderRadius;
 
-  + .visEditorSidebar__section {
+  +.visEditorSidebar__section {
     margin-top: $euiSizeS;
   }
 }
@@ -128,7 +128,7 @@ $vis-editor-sidebar-min-width: 350px;
   max-height: 250px;
 }
 
-.euiComboBoxOptionsList__rowWrap > div {
+.euiComboBoxOptionsList__rowWrap>div {
   height: 250px !important;
 }
 
@@ -163,5 +163,21 @@ $vis-editor-sidebar-min-width: 350px;
 
 #vis__mainContent .vis__leftPanel {
   overflow-y: unset; // unset default setting
+}
+
+.panelItem_button {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-gap: $euiSizeS;
+  padding: $euiSizeS $euiSizeM;
+  align-items: center;
+}
+
+.field_text {
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+.panel_section{
+  border-bottom: 1px solid #D3DAE6;
 }
 

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_style_slider.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_style_slider.tsx
@@ -4,45 +4,54 @@
  */
 
 import React, { ReactNode } from 'react';
-import { EuiTitle, EuiSpacer, EuiRange, htmlIdGenerator, } from '@elastic/eui';
+import { EuiTitle, EuiSpacer, EuiRange, htmlIdGenerator } from '@elastic/eui';
 
 export interface EuiRangeTick {
-    value: number;
-    label: ReactNode;
+  value: number;
+  label: ReactNode;
 }
 
 interface Props {
-    title: string;
-    currentRange: string;
-    minRange?: number;
-    maxRange: number;
-    showTicks?: boolean;
-    ticks?: EuiRangeTick[];
-    step: number;
-    handleSliderChange: (e: React.ChangeEvent<HTMLInputElement> | React.MouseEvent<HTMLButtonElement>) => void;
+  title: string;
+  currentRange: string;
+  minRange?: number;
+  maxRange: number;
+  showTicks?: boolean;
+  ticks?: EuiRangeTick[];
+  step: number;
+  handleSliderChange: (
+    e: React.ChangeEvent<HTMLInputElement> | React.MouseEvent<HTMLButtonElement>
+  ) => void;
 }
 
 export const SliderConfig: React.FC<Props> = ({
-    title, currentRange, handleSliderChange, minRange, maxRange, showTicks, ticks, step
+  title,
+  currentRange,
+  handleSliderChange,
+  minRange,
+  maxRange,
+  showTicks,
+  ticks,
+  step,
 }) => (
-    <>
-        <EuiTitle size="xxs">
-            <h3>{title}</h3>
-        </EuiTitle>
-        <EuiSpacer size="s" />
-        <EuiRange
-            aria-label="change lineWidth slider"
-            id={htmlIdGenerator('inputRangeSlider')()}
-            min={minRange}
-            max={maxRange}
-            name={title}
-            value={currentRange}
-            onChange={(e) => handleSliderChange(e.target.value)}
-            showTicks={showTicks}
-            ticks={ticks}
-            step={step}
-            compressed
-            showInput
-        />
-    </>
+  <>
+    <EuiTitle size="xxs">
+      <h3>{title}</h3>
+    </EuiTitle>
+    <EuiSpacer size="s" />
+    <EuiRange
+      aria-label="change lineWidth slider"
+      id={htmlIdGenerator('inputRangeSlider')()}
+      min={minRange}
+      max={maxRange}
+      name={title}
+      value={currentRange}
+      onChange={(e) => handleSliderChange(e.target.value)}
+      showTicks={showTicks}
+      ticks={ticks}
+      step={step}
+      compressed
+      showInput
+    />
+  </>
 );

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_treemap_parents.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_treemap_parents.tsx
@@ -6,12 +6,7 @@
 import { EuiButtonIcon, EuiPanel, EuiSpacer, EuiText } from '@elastic/eui';
 import { isEmpty } from 'lodash';
 import React from 'react';
-
-export interface ParentUnitType {
-  name: string;
-  label: string;
-  type: string;
-}
+import { ParentUnitType } from '../../../../../../../../common/types/explorer';
 
 export const ConfigTreemapParentFields = ({
   selectedAxis,
@@ -25,10 +20,13 @@ export const ConfigTreemapParentFields = ({
     type: '',
   };
 
-  const handleAddEditParent = (isAdd: boolean, index: number) => {
-    if (isAdd) {
-      handleUpdateParentFields([...selectedAxis, initialParentState]);
-    }
+  const handleAddParent = () => {
+    const arr = [...selectedAxis, initialParentState];
+    handleUpdateParentFields(arr);
+    setSelectedParentItem({ index: arr.length - 1, isClicked: true });
+  };
+
+  const handleEditParent = (index: number) => {
     setSelectedParentItem({ index, isClicked: true });
   };
 
@@ -47,11 +45,7 @@ export const ConfigTreemapParentFields = ({
             <>
               <EuiSpacer size="s" />
               <EuiPanel key={index} paddingSize="s" className="panelItem_button">
-                <EuiText
-                  size="s"
-                  className="field_text"
-                  onClick={() => handleAddEditParent(false, index)}
-                >
+                <EuiText size="s" className="field_text" onClick={() => handleEditParent(index)}>
                   <a role="button" tabIndex={0}>
                     {obj.label !== '' ? obj.label : `Parent ${index + 1}`}
                   </a>
@@ -75,7 +69,7 @@ export const ConfigTreemapParentFields = ({
           aria-label="clear-field"
           iconSize="s"
           color="primary"
-          onClick={() => handleAddEditParent(true, selectedAxis.length)}
+          onClick={handleAddParent}
         />
       </EuiPanel>
     </>

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_treemap_parents.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_treemap_parents.tsx
@@ -5,7 +5,7 @@
 
 import { EuiButtonIcon, EuiPanel, EuiSpacer, EuiText } from '@elastic/eui';
 import { isEmpty } from 'lodash';
-import React from 'react';
+import React, { Fragment } from 'react';
 import { ParentUnitType } from '../../../../../../../../common/types/explorer';
 
 export const ConfigTreemapParentFields = ({
@@ -42,9 +42,9 @@ export const ConfigTreemapParentFields = ({
       {!isEmpty(selectedAxis) &&
         selectedAxis.map((obj: ParentUnitType, index: number) => {
           return (
-            <>
+            <Fragment key={index}>
               <EuiSpacer size="s" />
-              <EuiPanel key={index} paddingSize="s" className="panelItem_button">
+              <EuiPanel paddingSize="s" className="panelItem_button">
                 <EuiText size="s" className="field_text" onClick={() => handleEditParent(index)}>
                   <a role="button" tabIndex={0}>
                     {obj.label !== '' ? obj.label : `Parent ${index + 1}`}
@@ -58,7 +58,7 @@ export const ConfigTreemapParentFields = ({
                   onClick={() => handleParentDelete(index)}
                 />
               </EuiPanel>
-            </>
+            </Fragment>
           );
         })}
       <EuiSpacer size="s" />

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_treemap_parents.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_treemap_parents.tsx
@@ -3,17 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { Fragment } from 'react';
-import {
-  EuiButton,
-  EuiFormRow,
-  EuiSpacer,
-  EuiIcon,
-  EuiComboBox,
-  EuiComboBoxOptionOption,
-  EuiText,
-} from '@elastic/eui';
-import { isEmpty, uniqueId } from 'lodash';
+import { EuiButtonIcon, EuiPanel, EuiSpacer, EuiText } from '@elastic/eui';
+import { isEmpty } from 'lodash';
+import React from 'react';
 
 export interface ParentUnitType {
   name: string;
@@ -21,36 +13,27 @@ export interface ParentUnitType {
   type: string;
 }
 
-export const ConfigTreemapParentFields = ({ dropdownList, selectedAxis, onSelectChange }: any) => {
-  const addButtonText = '+ Add Parent';
-
-  const options = dropdownList.map((item) => {
-    return {
-      ...item,
-      label: item.name,
-    };
-  });
-
+export const ConfigTreemapParentFields = ({
+  selectedAxis,
+  setSelectedParentItem,
+  handleUpdateParentFields,
+}: any) => {
+  const addButtonText = 'Add Parent';
   const initialParentState = {
     name: '',
     label: '',
     type: '',
   };
 
-  const handleAddParent = () => {
-    onSelectChange([...selectedAxis, initialParentState]);
-  };
-
-  const handleParentChange = (options: EuiComboBoxOptionOption<unknown>[], index: number) => {
-    onSelectChange([
-      ...selectedAxis.slice(0, index),
-      (options[0] as ParentUnitType) ?? initialParentState,
-      ...selectedAxis.slice(index + 1, selectedAxis.length),
-    ]);
+  const handleAddEditParent = (isAdd: boolean, index: number) => {
+    if (isAdd) {
+      handleUpdateParentFields([...selectedAxis, initialParentState]);
+    }
+    setSelectedParentItem({ index, isClicked: true });
   };
 
   const handleParentDelete = (index: number) => {
-    onSelectChange([
+    handleUpdateParentFields([
       ...selectedAxis.slice(0, index),
       ...selectedAxis.slice(index + 1, selectedAxis.length),
     ]);
@@ -59,41 +42,42 @@ export const ConfigTreemapParentFields = ({ dropdownList, selectedAxis, onSelect
   return (
     <>
       {!isEmpty(selectedAxis) &&
-        selectedAxis.map((_, index: number) => {
+        selectedAxis.map((obj: ParentUnitType, index: number) => {
           return (
-            <Fragment key={index}>
+            <>
               <EuiSpacer size="s" />
-              <EuiFormRow
-                label={`Parent ${index + 1}`}
-                labelAppend={
-                  <EuiText size="xs">
-                    <EuiIcon
-                      type="cross"
-                      color="danger"
-                      onClick={() => handleParentDelete(index)}
-                    />
-                  </EuiText>
-                }
-              >
-                <EuiComboBox
-                  id={uniqueId('axis-select-')}
-                  placeholder="Select a field"
-                  options={options}
-                  selectedOptions={selectedAxis[index].label !== '' ? [selectedAxis[index]] : []}
-                  isClearable={true}
-                  singleSelection={{ asPlainText: true }}
-                  onChange={(options) => handleParentChange(options, index)}
-                  aria-label="Use aria labels when no actual label is in use"
+              <EuiPanel key={index} paddingSize="s" className="panelItem_button">
+                <EuiText
+                  size="s"
+                  className="field_text"
+                  onClick={() => handleAddEditParent(false, index)}
+                >
+                  <a role="button" tabIndex={0}>
+                    {obj.label !== '' ? obj.label : `Parent ${index + 1}`}
+                  </a>
+                </EuiText>
+                <EuiButtonIcon
+                  color="subdued"
+                  iconType="cross"
+                  aria-label="clear-field"
+                  iconSize="s"
+                  onClick={() => handleParentDelete(index)}
                 />
-              </EuiFormRow>
-            </Fragment>
+              </EuiPanel>
+            </>
           );
         })}
       <EuiSpacer size="s" />
-      <EuiSpacer size="s" />
-      <EuiButton data-test-subj="addParentButton" fullWidth size="s" onClick={handleAddParent}>
-        {addButtonText}
-      </EuiButton>
+      <EuiPanel className="panelItem_button" grow>
+        <EuiText size="s">{addButtonText}</EuiText>
+        <EuiButtonIcon
+          iconType="plusInCircle"
+          aria-label="clear-field"
+          iconSize="s"
+          color="primary"
+          onClick={() => handleAddEditParent(true, selectedAxis.length)}
+        />
+      </EuiPanel>
     </>
   );
 };

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_treemap_parents.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_treemap_parents.tsx
@@ -3,16 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButtonIcon, EuiPanel, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiButtonIcon, EuiLink, EuiPanel, EuiSpacer, EuiText } from '@elastic/eui';
 import { isEmpty } from 'lodash';
 import React, { Fragment } from 'react';
-import { ParentUnitType } from '../../../../../../../../common/types/explorer';
+import { ParentUnitType, TreemapParentsProps } from '../../../../../../../../common/types/explorer';
 
 export const ConfigTreemapParentFields = ({
   selectedAxis,
   setSelectedParentItem,
   handleUpdateParentFields,
-}: any) => {
+}: TreemapParentsProps) => {
   const addButtonText = 'Add Parent';
   const initialParentState = {
     name: '',
@@ -45,10 +45,10 @@ export const ConfigTreemapParentFields = ({
             <Fragment key={index}>
               <EuiSpacer size="s" />
               <EuiPanel paddingSize="s" className="panelItem_button">
-                <EuiText size="s" className="field_text" onClick={() => handleEditParent(index)}>
-                  <a role="button" tabIndex={0}>
+                <EuiText size="s" className="field_text">
+                  <EuiLink role="button" tabIndex={0} onClick={() => handleEditParent(index)}>
                     {obj.label !== '' ? obj.label : `Parent ${index + 1}`}
-                  </a>
+                  </EuiLink>
                 </EuiText>
                 <EuiButtonIcon
                   color="subdued"

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_item_click_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_item_click_panel.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import React from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiIcon,
+  EuiSpacer,
+  EuiTitle,
+} from '@elastic/eui';
+export interface TitleProps {
+  title: string;
+  isSecondary?: boolean;
+  closeMenu?: () => void;
+}
+
+export const DataConfigItemClickPanel = ({ title, isSecondary, closeMenu }: TitleProps) => {
+  const icon = isSecondary && (
+    <EuiIcon type="arrowLeft" onClick={closeMenu} data-test-subj="panelCloseBtn" />
+  );
+  return (
+    <>
+      <div className="wizConfig__title">
+        <EuiFlexGroup gutterSize="s" alignItems="center">
+          {icon && <EuiFlexItem grow={false}>{icon}</EuiFlexItem>}
+          <EuiFlexItem>
+            <EuiTitle size="xxs">
+              <h2>{title}</h2>
+            </EuiTitle>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </div>
+      {isSecondary ? <EuiHorizontalRule margin="s" /> : <EuiSpacer size="s" />}
+    </>
+  );
+};

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_item_click_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_item_click_panel.tsx
@@ -26,7 +26,7 @@ export const DataConfigItemClickPanel = ({ title, isSecondary, closeMenu }: Titl
       <EuiFlexGroup gutterSize="s" alignItems="center">
         {icon && <EuiFlexItem grow={false}>{icon}</EuiFlexItem>}
         <EuiFlexItem>
-          <EuiTitle size="xxs">
+          <EuiTitle size="xxs" className="panel_title">
             <h2>{title}</h2>
           </EuiTitle>
         </EuiFlexItem>

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_item_click_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_item_click_panel.tsx
@@ -23,16 +23,14 @@ export const DataConfigItemClickPanel = ({ title, isSecondary, closeMenu }: Titl
   );
   return (
     <>
-      <div className="wizConfig__title">
-        <EuiFlexGroup gutterSize="s" alignItems="center">
-          {icon && <EuiFlexItem grow={false}>{icon}</EuiFlexItem>}
-          <EuiFlexItem>
-            <EuiTitle size="xxs">
-              <h2>{title}</h2>
-            </EuiTitle>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </div>
+      <EuiFlexGroup gutterSize="s" alignItems="center">
+        {icon && <EuiFlexItem grow={false}>{icon}</EuiFlexItem>}
+        <EuiFlexItem>
+          <EuiTitle size="xxs">
+            <h2>{title}</h2>
+          </EuiTitle>
+        </EuiFlexItem>
+      </EuiFlexGroup>
       {isSecondary ? <EuiHorizontalRule margin="s" /> : <EuiSpacer size="s" />}
     </>
   );

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
@@ -2,7 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import React from 'react';
+import React, { Fragment } from 'react';
 import { EuiButtonIcon, EuiPanel, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
 import { ConfigListEntry } from '../../../../../../../../common/types/explorer';
 import { VIS_CHART_TYPES } from '../../../../../../../../common/constants/shared';
@@ -37,8 +37,8 @@ export const DataConfigPanelFields = ({
       <EuiSpacer size="s" />
       {list !== undefined &&
         list.map((obj: ConfigListEntry, index: number) => (
-          <>
-            <EuiPanel key={index} paddingSize="s" className="panelItem_button">
+          <Fragment key={index}>
+            <EuiPanel paddingSize="s" className="panelItem_button">
               <EuiText
                 size="s"
                 className="field_text"
@@ -58,7 +58,7 @@ export const DataConfigPanelFields = ({
               />
             </EuiPanel>
             <EuiSpacer size="s" />
-          </>
+          </Fragment>
         ))}
       {!isHeatMapAddButton(sectionName) && (
         <EuiPanel className="panelItem_button" grow>

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
@@ -6,7 +6,11 @@ import React from 'react';
 import { EuiButtonIcon, EuiPanel, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
 import { ConfigListEntry } from '../../../../../../../../common/types/explorer';
 import { VIS_CHART_TYPES } from '../../../../../../../../common/constants/shared';
-import { AGGREGATIONS, GROUPBY } from '../../../../../../../../common/constants/explorer';
+import {
+  AGGREGATIONS,
+  CUSTOM_LABEL,
+  GROUPBY,
+} from '../../../../../../../../common/constants/explorer';
 
 export const DataConfigPanelFields = ({
   list,
@@ -41,7 +45,7 @@ export const DataConfigPanelFields = ({
                 onClick={() => handleServiceEdit(false, index, sectionName)}
               >
                 <a role="button" tabIndex={0}>
-                  {obj?.alias ||
+                  {obj[CUSTOM_LABEL] ||
                     `${sectionName === AGGREGATIONS ? obj.aggregation : ''} ${obj.label}`}
                 </a>
               </EuiText>

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
@@ -5,23 +5,30 @@
 import React from 'react';
 import { EuiButtonIcon, EuiPanel, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
 import { ConfigListEntry } from '../../../../../../../../common/types/explorer';
-import { visChartTypes } from '../../../../../../../../common/constants/shared';
+import { VIS_CHART_TYPES } from '../../../../../../../../common/constants/shared';
+import { AGGREGATIONS, GROUPBY } from '../../../../../../../../common/constants/explorer';
 
 export const DataConfigPanelFields = ({
   list,
   sectionName,
-  title,
   visType,
   addButtonText,
   handleServiceAdd,
   handleServiceRemove,
   handleServiceEdit,
 }: any) => {
-  const isHeatMap = visType === visChartTypes.HeatMap && list?.length >= 1;
+  const isHeatMapAddButton = (name: string) => {
+    if (visType === VIS_CHART_TYPES.HeatMap) {
+      if (name === AGGREGATIONS) return list?.length === 1;
+      return !(list?.length < 2);
+    }
+    return false;
+  };
+
   return (
     <div className="panel_section">
-      <EuiTitle size="xxs">
-        <h3>{title}</h3>
+      <EuiTitle size="xxs" className="panel_title">
+        <h3>{sectionName}</h3>
       </EuiTitle>
       <EuiSpacer size="s" />
       {list !== undefined &&
@@ -34,7 +41,8 @@ export const DataConfigPanelFields = ({
                 onClick={() => handleServiceEdit(false, index, sectionName)}
               >
                 <a role="button" tabIndex={0}>
-                  {obj?.alias || obj.label}
+                  {obj?.alias ||
+                    `${sectionName === AGGREGATIONS ? obj.aggregation : ''} ${obj.label}`}
                 </a>
               </EuiText>
               <EuiButtonIcon
@@ -48,7 +56,7 @@ export const DataConfigPanelFields = ({
             <EuiSpacer size="s" />
           </>
         ))}
-      {!isHeatMap && (
+      {!isHeatMapAddButton(sectionName) && (
         <EuiPanel className="panelItem_button" grow>
           <EuiText size="s">{addButtonText}</EuiText>
           <EuiButtonIcon
@@ -56,7 +64,7 @@ export const DataConfigPanelFields = ({
             aria-label="add-field"
             iconSize="s"
             color="primary"
-            disabled={sectionName === 'dimensions' && visType === visChartTypes.Line}
+            disabled={sectionName === GROUPBY && visType === VIS_CHART_TYPES.Line}
             onClick={() => handleServiceAdd(sectionName)}
           />
         </EuiPanel>

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
@@ -3,8 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React, { Fragment } from 'react';
-import { EuiButtonIcon, EuiPanel, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
-import { ConfigListEntry } from '../../../../../../../../common/types/explorer';
+import { EuiButtonIcon, EuiLink, EuiPanel, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import { isArray } from 'lodash';
+import {
+  ConfigListEntry,
+  DataConfigPanelFieldProps,
+} from '../../../../../../../../common/types/explorer';
 import { VIS_CHART_TYPES } from '../../../../../../../../common/constants/shared';
 import {
   AGGREGATIONS,
@@ -20,13 +24,10 @@ export const DataConfigPanelFields = ({
   handleServiceAdd,
   handleServiceRemove,
   handleServiceEdit,
-}: any) => {
+}: DataConfigPanelFieldProps) => {
   const isHeatMapAddButton = (name: string) => {
-    if (visType === VIS_CHART_TYPES.HeatMap) {
-      if (name === AGGREGATIONS) return list?.length === 1;
-      return !(list?.length < 2);
-    }
-    return false;
+    if (!list || !isArray(list) || visType !== VIS_CHART_TYPES.HeatMap) return false;
+    return name === AGGREGATIONS ? list.length === 1 : !(list?.length < 2);
   };
 
   return (
@@ -36,18 +37,19 @@ export const DataConfigPanelFields = ({
       </EuiTitle>
       <EuiSpacer size="s" />
       {list !== undefined &&
+        isArray(list) &&
         list.map((obj: ConfigListEntry, index: number) => (
           <Fragment key={index}>
             <EuiPanel paddingSize="s" className="panelItem_button">
-              <EuiText
-                size="s"
-                className="field_text"
-                onClick={() => handleServiceEdit(false, index, sectionName)}
-              >
-                <a role="button" tabIndex={0}>
+              <EuiText size="s" className="field_text">
+                <EuiLink
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => handleServiceEdit(false, index, sectionName)}
+                >
                   {obj[CUSTOM_LABEL] ||
                     `${sectionName === AGGREGATIONS ? obj.aggregation : ''} ${obj.label}`}
-                </a>
+                </EuiLink>
               </EuiText>
               <EuiButtonIcon
                 color="subdued"

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
@@ -3,7 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import React, { Fragment } from 'react';
-import { EuiButtonIcon, EuiLink, EuiPanel, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import {
+  EuiButtonIcon,
+  EuiIcon,
+  EuiLink,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+  EuiToolTip,
+} from '@elastic/eui';
 import { isArray } from 'lodash';
 import {
   ConfigListEntry,
@@ -25,16 +34,42 @@ export const DataConfigPanelFields = ({
   handleServiceRemove,
   handleServiceEdit,
 }: DataConfigPanelFieldProps) => {
+  const isAggregation = sectionName === AGGREGATIONS;
   const isHeatMapAddButton = (name: string) => {
     if (!list || !isArray(list) || visType !== VIS_CHART_TYPES.HeatMap) return false;
     return name === AGGREGATIONS ? list.length >= 1 : list.length >= 2;
   };
 
+  const tooltipIcon = <EuiIcon type="iInCircle" color="text" size="m" className="info-icon" />;
+  const crossIcon = (index: number) => (
+    <EuiButtonIcon
+      color="subdued"
+      iconType="cross"
+      aria-label="clear-field"
+      iconSize="s"
+      onClick={() => handleServiceRemove(index, sectionName)}
+    />
+  );
+
+  const aggregationToolTip = (iconToDisplay: JSX.Element) => (
+    <EuiToolTip
+      position="right"
+      content="At least one metric is required to render a chart"
+      delay="regular"
+      anchorClassName="eui-textTruncate"
+    >
+      {iconToDisplay}
+    </EuiToolTip>
+  );
+
   return (
     <div className="panel_section">
-      <EuiTitle size="xxs" className="panel_title">
-        <h3>{sectionName}</h3>
-      </EuiTitle>
+      <div style={{ display: 'flex' }}>
+        <EuiTitle size="xxs" className="panel_title">
+          <h3>{sectionName}</h3>
+        </EuiTitle>
+        {isAggregation && aggregationToolTip(tooltipIcon)}
+      </div>
       <EuiSpacer size="s" />
       {isArray(list) &&
         list.map((obj: ConfigListEntry, index: number) => (
@@ -46,17 +81,10 @@ export const DataConfigPanelFields = ({
                   tabIndex={0}
                   onClick={() => handleServiceEdit(false, index, sectionName)}
                 >
-                  {obj[CUSTOM_LABEL] ||
-                    `${sectionName === AGGREGATIONS ? obj.aggregation : ''} ${obj.label}`}
+                  {obj[CUSTOM_LABEL] || `${isAggregation ? obj.aggregation : ''} ${obj.label}`}
                 </EuiLink>
               </EuiText>
-              <EuiButtonIcon
-                color="subdued"
-                iconType="cross"
-                aria-label="clear-field"
-                iconSize="s"
-                onClick={() => handleServiceRemove(index, sectionName)}
-              />
+              {isAggregation ? aggregationToolTip(crossIcon(index)) : crossIcon(index)}
             </EuiPanel>
             <EuiSpacer size="s" />
           </Fragment>
@@ -69,7 +97,10 @@ export const DataConfigPanelFields = ({
             aria-label="add-field"
             iconSize="s"
             color="primary"
-            disabled={sectionName === GROUPBY && visType === VIS_CHART_TYPES.Line}
+            disabled={
+              (sectionName === GROUPBY && visType === VIS_CHART_TYPES.Line) ||
+              visType === VIS_CHART_TYPES.Scatter
+            }
             onClick={() => handleServiceAdd(sectionName)}
           />
         </EuiPanel>

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
@@ -27,7 +27,7 @@ export const DataConfigPanelFields = ({
 }: DataConfigPanelFieldProps) => {
   const isHeatMapAddButton = (name: string) => {
     if (!list || !isArray(list) || visType !== VIS_CHART_TYPES.HeatMap) return false;
-    return name === AGGREGATIONS ? list.length === 1 : !(list?.length < 2);
+    return name === AGGREGATIONS ? list.length >= 1 : list.length >= 2;
   };
 
   return (
@@ -36,8 +36,7 @@ export const DataConfigPanelFields = ({
         <h3>{sectionName}</h3>
       </EuiTitle>
       <EuiSpacer size="s" />
-      {list !== undefined &&
-        isArray(list) &&
+      {isArray(list) &&
         list.map((obj: ConfigListEntry, index: number) => (
           <Fragment key={index}>
             <EuiPanel paddingSize="s" className="panelItem_button">

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import React from 'react';
+import { EuiButtonIcon, EuiPanel, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import { ConfigListEntry } from '../../../../../../../../common/types/explorer';
+import { visChartTypes } from '../../../../../../../../common/constants/shared';
+
+export const DataConfigPanelFields = ({
+  list,
+  sectionName,
+  title,
+  visType,
+  addButtonText,
+  handleServiceAdd,
+  handleServiceRemove,
+  handleServiceEdit,
+}: any) => {
+  const isHeatMap = visType === visChartTypes.HeatMap && list?.length >= 1;
+  return (
+    <div className="panel_section">
+      <EuiTitle size="xxs">
+        <h3>{title}</h3>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+      {list !== undefined &&
+        list.map((obj: ConfigListEntry, index: number) => (
+          <>
+            <EuiPanel key={index} paddingSize="s" className="panelItem_button">
+              <EuiText
+                size="s"
+                className="field_text"
+                onClick={() => handleServiceEdit(false, index, sectionName)}
+              >
+                <a role="button" tabIndex={0}>
+                  {obj?.alias || obj.label}
+                </a>
+              </EuiText>
+              <EuiButtonIcon
+                color="subdued"
+                iconType="cross"
+                aria-label="clear-field"
+                iconSize="s"
+                onClick={() => handleServiceRemove(index, sectionName)}
+              />
+            </EuiPanel>
+            <EuiSpacer size="s" />
+          </>
+        ))}
+      {!isHeatMap && (
+        <EuiPanel className="panelItem_button" grow>
+          <EuiText size="s">{addButtonText}</EuiText>
+          <EuiButtonIcon
+            iconType="plusInCircle"
+            aria-label="clear-field"
+            iconSize="s"
+            color="primary"
+            disabled={sectionName === 'dimensions' && visType === visChartTypes.Line}
+            onClick={() => handleServiceAdd(sectionName)}
+          />
+        </EuiPanel>
+      )}
+      <EuiSpacer size="m" />
+    </div>
+  );
+};

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
@@ -53,7 +53,7 @@ export const DataConfigPanelFields = ({
           <EuiText size="s">{addButtonText}</EuiText>
           <EuiButtonIcon
             iconType="plusInCircle"
-            aria-label="clear-field"
+            aria-label="add-field"
             iconSize="s"
             color="primary"
             disabled={sectionName === 'dimensions' && visType === visChartTypes.Line}

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -24,6 +24,7 @@ import { batch, useDispatch } from 'react-redux';
 import {
   AGGREGATIONS,
   AGGREGATION_OPTIONS,
+  CUSTOM_LABEL,
   GROUPBY,
   RAW_QUERY,
   TIMESTAMP,
@@ -137,7 +138,7 @@ export const DataConfigPanelItem = ({
     let listItem = { ...configList[name][index] };
     listItem = {
       ...listItem,
-      [field === 'custom_label' ? 'alias' : field]: value.trim(),
+      [field]: field === 'custom_label' ? value.trim() : value,
     };
     if (field === 'label') {
       listItem.name = value;
@@ -235,7 +236,7 @@ export const DataConfigPanelItem = ({
             },
           })
         );
-        await fetchData();
+        await fetchData(false);
         await dispatch(
           changeVizConfig({
             tabId,
@@ -313,8 +314,8 @@ export const DataConfigPanelItem = ({
                   <EuiFormRow label="Custom label">
                     <EuiFieldText
                       placeholder="Custom label"
-                      value={selectedObj.alias}
-                      onChange={(e) => updateList(e.target.value, 'alias')}
+                      value={selectedObj[CUSTOM_LABEL]}
+                      onChange={(e) => updateList(e.target.value, CUSTOM_LABEL)}
                       aria-label="input label"
                     />
                   </EuiFormRow>

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -29,7 +29,6 @@ import {
   RAW_QUERY,
   TIMESTAMP,
   TIME_INTERVAL_OPTIONS,
-  CUSTOM_LABEL,
 } from '../../../../../../../../common/constants/explorer';
 import { VIS_CHART_TYPES } from '../../../../../../../../common/constants/shared';
 import { composeAggregations } from '../../../../../../../../common/query_manager/utils';
@@ -278,7 +277,7 @@ export const DataConfigPanelItem = ({
     const isDimensions = name === GROUPBY;
     return (
       <>
-        <div key={index} className="services">
+        <div className="services">
           <div className="first-division">
             <DataConfigItemClickPanel
               isSecondary

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -5,7 +5,7 @@
 
 import './data_configurations_panel.scss';
 
-import React, { useEffect, useState, useContext, useCallback, useMemo } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { some } from 'lodash';
 import {
   EuiButton,
@@ -20,7 +20,6 @@ import {
   htmlIdGenerator,
   EuiToolTip,
 } from '@elastic/eui';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { batch, useDispatch } from 'react-redux';
 import {
   AGGREGATIONS,
@@ -34,8 +33,6 @@ import {
 } from '../../../../../../../../common/constants/explorer';
 import { ButtonGroupItem } from './config_button_group';
 import { VIS_CHART_TYPES } from '../../../../../../../../common/constants/shared';
-import { ConfigList, DataConfigPanelProps } from '../../../../../../../../common/types/explorer';
-import { TabContext } from '../../../../../hooks';
 import { composeAggregations } from '../../../../../../../../common/query_manager/utils';
 import {
   ConfigList,
@@ -47,7 +44,6 @@ import { changeQuery } from '../../../../../redux/slices/query_slice';
 import { change as changeVizConfig } from '../../../../../redux/slices/viualization_config_slice';
 import { DataConfigItemClickPanel } from '../config_controls/data_config_item_click_panel';
 import { DataConfigPanelFields } from '../config_controls/data_config_panel_fields';
-import { ButtonGroupItem } from './config_button_group';
 
 const initialDimensionEntry = {
   label: '',
@@ -129,8 +125,7 @@ export const DataConfigPanelItem = ({
   const updateList = (value: string, field: string) => {
     if (value !== '') {
       const { index, name } = selectedConfigItem;
-      const list = { ...configList };
-      let listItem = { ...list[name][index] };
+      let listItem = { ...configList[name][index] };
       listItem = {
         ...listItem,
         [field === 'custom_label' ? 'alias' : field]: value.trim(),
@@ -139,11 +134,11 @@ export const DataConfigPanelItem = ({
         listItem.name = value;
       }
       const updatedList = {
-        ...list,
+        ...configList,
         [name]: [
-          ...list[name].slice(0, index),
+          ...configList[name].slice(0, index),
           listItem,
-          ...list[name].slice(index + 1, list[name].length),
+          ...configList[name].slice(index + 1, configList[name].length),
         ],
       };
       setConfigList(updatedList);
@@ -269,7 +264,7 @@ export const DataConfigPanelItem = ({
               {!isDimensions && (
                 <EuiFormRow label="Aggregation">
                   <EuiComboBox
-                    aria-label="Accessible screen reader label"
+                    aria-label="aggregation input"
                     placeholder="Select a aggregation"
                     singleSelection={{ asPlainText: true }}
                     options={AGGREGATION_OPTIONS}
@@ -295,7 +290,7 @@ export const DataConfigPanelItem = ({
                       placeholder="Custom label"
                       value={selectedObj.alias}
                       onChange={(e) => updateList(e.target.value, 'alias')}
-                      aria-label="Use aria labels when no actual label is in use"
+                      aria-label="input label"
                     />
                   </EuiFormRow>
                 </>
@@ -320,13 +315,13 @@ export const DataConfigPanelItem = ({
           </div>
         </div>
       </>
-  );
+    );
   };
 
-  const getCommonDimensionsField = (selectedObj: any, name: string) => (
+  const getCommonDimensionsField = (selectedObj: ConfigListEntry, name: string) => (
     <EuiFormRow label="Field">
       <EuiComboBox
-        aria-label="Accessible screen reader label"
+        aria-label="input field"
         placeholder="Select a field"
         singleSelection={{ asPlainText: true }}
         options={getOptionsAvailable(name)}
@@ -407,7 +402,7 @@ export const DataConfigPanelItem = ({
             <EuiPanel color="subdued" style={{ padding: '0px' }}>
               <EuiFormRow label="Timestamp">
                 <EuiComboBox
-                  aria-label="Accessible screen reader label"
+                  aria-label="Timestamp field"
                   placeholder="Select fields"
                   singleSelection
                   options={availableFields
@@ -446,12 +441,12 @@ export const DataConfigPanelItem = ({
                       };
                     });
                   }}
-                  aria-label="Use aria labels when no actual label is in use"
+                  aria-label="interval field"
                 />
               </EuiFormRow>
               <EuiFormRow label="Unit">
                 <EuiComboBox
-                  aria-label="Accessible screen reader label"
+                  aria-label="date unit"
                   placeholder="Select fields"
                   singleSelection
                   options={TIME_INTERVAL_OPTIONS.map((option) => {

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -62,15 +62,7 @@ export const DataConfigPanelItem = ({
   queryManager,
 }: DataConfigPanelProps) => {
   const dispatch = useDispatch();
-  const {
-    tabId,
-    handleQuerySearch,
-    handleQueryChange,
-    setTempQuery,
-    fetchData,
-    changeVisualizationConfig,
-    curVisId,
-  } = useContext<any>(TabContext);
+  const { tabId, handleQueryChange, fetchData, curVisId } = useContext<any>(TabContext);
   const { data } = visualizations;
   const { data: vizData = {}, metadata: { fields = [] } = {} } = data?.rawVizData;
   const {
@@ -89,43 +81,6 @@ export const DataConfigPanelItem = ({
       setConfigList({
         ...userConfigs.dataConfig,
       });
-    } else if (some(SPECIAL_RENDERING_VIZS, (visType) => visType === visualizations.vis.name)) {
-      // any vis that doesn't conform normal metrics/dimensions data confiurations
-      setConfigList({
-        ...DEFAULT_DATA_CONFIGS[visualizations.vis.name],
-      });
-    } else {
-      // default
-      const statsTokens = queryManager.queryParser().parse(data.query.rawQuery).getStats();
-      if (!statsTokens) {
-        setConfigList({
-          metrics: [],
-          dimensions: [],
-        });
-      } else {
-        const fieldInfo = statsTokens.groupby?.span?.span_expression?.field;
-        setConfigList({
-          metrics: statsTokens.aggregations.map((agg) => ({
-            alias: agg.alias,
-            label: agg.function?.value_expression,
-            name: agg.function?.value_expression,
-            aggregation: agg.function?.name,
-          })),
-          dimensions: statsTokens.groupby?.group_fields?.map((agg) => ({
-            label: agg.name ?? '',
-            name: agg.name ?? '',
-          })),
-          span: {
-            time_field: statsTokens.groupby?.span?.span_expression?.field
-              ? [getStandardedOuiField(fieldInfo, 'timestamp')]
-              : [],
-            interval: statsTokens.groupby?.span?.span_expression?.literal_value ?? '0',
-            unit: statsTokens.groupby?.span?.span_expression?.time_unit
-              ? [getStandardedOuiField(statsTokens.groupby?.span?.span_expression?.time_unit)]
-              : [],
-          },
-        });
-      }
     }
   }, [userConfigs?.dataConfig, visualizations.vis.name]);
 
@@ -386,7 +341,7 @@ export const DataConfigPanelItem = ({
     [configList[GROUPBY]]
   );
 
-  const Breakdowns = useMemo(() => {
+  const Breakdowns = () => {
     return (
       <>
         <div className="services">
@@ -414,7 +369,7 @@ export const DataConfigPanelItem = ({
         </div>
       </>
     );
-  }, [configList[GROUPBY], configList.breakdowns]);
+  };
 
   const DateHistogram = useMemo(() => {
     return (

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -26,17 +26,15 @@ import {
   AGGREGATION_OPTIONS,
   GROUPBY,
   RAW_QUERY,
-  SERIES,
   TIMESTAMP,
   TIME_INTERVAL_OPTIONS,
   CUSTOM_LABEL,
 } from '../../../../../../../../common/constants/explorer';
-import { ButtonGroupItem } from './config_button_group';
 import { VIS_CHART_TYPES } from '../../../../../../../../common/constants/shared';
 import { composeAggregations } from '../../../../../../../../common/query_manager/utils';
 import {
   ConfigList,
-  SelectedConfigItem,
+  ConfigListEntry,
   DataConfigPanelProps,
 } from '../../../../../../../../common/types/explorer';
 import { TabContext } from '../../../../../hooks';
@@ -63,7 +61,19 @@ export const DataConfigPanelItem = ({
   queryManager,
 }: DataConfigPanelProps) => {
   const dispatch = useDispatch();
+<<<<<<< HEAD:dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
   const { tabId, handleQueryChange, fetchData, curVisId } = useContext<any>(TabContext);
+=======
+  const {
+    tabId,
+    handleQuerySearch,
+    handleQueryChange,
+    setTempQuery,
+    fetchData,
+    changeVisualizationConfig,
+    curVisId,
+  } = useContext<any>(TabContext);
+>>>>>>> 9211985 (Made code compatible with PR changes):dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_item.tsx
   const { data } = visualizations;
   const { data: vizData = {}, metadata: { fields = [] } = {} } = data?.rawVizData;
   const {
@@ -123,26 +133,24 @@ export const DataConfigPanelItem = ({
   }, [userConfigs?.dataConfig, visualizations.vis.name]);
 
   const updateList = (value: string, field: string) => {
-    if (value !== '') {
-      const { index, name } = selectedConfigItem;
-      let listItem = { ...configList[name][index] };
-      listItem = {
-        ...listItem,
-        [field === 'custom_label' ? 'alias' : field]: value.trim(),
-      };
-      if (field === 'label') {
-        listItem.name = value;
-      }
-      const updatedList = {
-        ...configList,
-        [name]: [
-          ...configList[name].slice(0, index),
-          listItem,
-          ...configList[name].slice(index + 1, configList[name].length),
-        ],
-      };
-      setConfigList(updatedList);
+    const { index, name } = selectedConfigItem;
+    let listItem = { ...configList[name][index] };
+    listItem = {
+      ...listItem,
+      [field === 'custom_label' ? 'alias' : field]: value.trim(),
+    };
+    if (field === 'label') {
+      listItem.name = value;
     }
+    const updatedList = {
+      ...configList,
+      [name]: [
+        ...configList[name].slice(0, index),
+        listItem,
+        ...configList[name].slice(index + 1, configList[name].length),
+      ],
+    };
+    setConfigList(updatedList);
   };
 
   const updateHistogramConfig = (configName: string, fieldName: string, value: string) => {
@@ -177,7 +185,24 @@ export const DataConfigPanelItem = ({
     setConfigList(list);
   };
 
-  const updateChart = (updatedConfigList: ConfigList = configList) => {
+  const handleServiceEdit = (isClose: boolean, arrIndex: number, sectionName: string) => {
+    if (isClose) {
+      const { index, name } = selectedConfigItem;
+      const selectedObj = configList[name][index];
+      if (
+        selectedObj.aggregation !== 'count' &&
+        (selectedObj.aggregation === '' || selectedObj.name === '')
+      ) {
+        const list = { ...configList };
+        list[name].splice(index, 1);
+        setConfigList(list);
+      }
+    }
+    setSelectedConfigItem({ index: arrIndex, name: sectionName });
+    setIsAddConfigClicked(!isClose);
+  };
+
+  const updateChart = (updatedConfigList = configList) => {
     if (visualizations.vis.name === VIS_CHART_TYPES.Histogram) {
       dispatch(
         changeVizConfig({
@@ -187,8 +212,8 @@ export const DataConfigPanelItem = ({
             ...userConfigs,
             dataConfig: {
               ...userConfigs.dataConfig,
-              [GROUPBY]: configList[GROUPBY],
-              [AGGREGATIONS]: configList[AGGREGATIONS],
+              [GROUPBY]: updatedConfigList[GROUPBY],
+              [AGGREGATIONS]: updatedConfigList[AGGREGATIONS],
             },
           },
         })
@@ -218,8 +243,8 @@ export const DataConfigPanelItem = ({
             data: {
               dataConfig: {
                 ...userConfigs.dataConfig,
-                [GROUPBY]: configList[GROUPBY],
-                [AGGREGATIONS]: configList[AGGREGATIONS],
+                [GROUPBY]: updatedConfigList[GROUPBY],
+                [AGGREGATIONS]: updatedConfigList[AGGREGATIONS],
                 breakdowns: updatedConfigList.breakdowns,
                 span: updatedConfigList.span,
               },
@@ -249,7 +274,7 @@ export const DataConfigPanelItem = ({
   const getCommonUI = (title: string) => {
     const { index, name } = selectedConfigItem;
     const selectedObj = configList[name][index];
-    const isDimensions = name === DIMENSIONS;
+    const isDimensions = name === GROUPBY;
     return (
       <>
         <div key={index} className="services">
@@ -260,7 +285,7 @@ export const DataConfigPanelItem = ({
               closeMenu={() => handleServiceEdit(true, -1, '')}
             />
             <EuiPanel color="subdued" style={{ padding: '0px' }}>
-              {/* Aggregation input for Metrics */}
+              {/* Aggregation input for Series */}
               {!isDimensions && (
                 <EuiFormRow label="Aggregation">
                   <EuiComboBox
@@ -281,7 +306,7 @@ export const DataConfigPanelItem = ({
                   />
                 </EuiFormRow>
               )}
-              {/* Show input fields for metrics when aggregation is not empty  */}
+              {/* Show input fields for Series when aggregation is not empty  */}
               {!isDimensions && selectedObj.aggregation !== '' && (
                 <>
                   {getCommonDimensionsField(selectedObj, name)}
@@ -350,7 +375,7 @@ export const DataConfigPanelItem = ({
             ? configList[GROUPBY][0][type]
             : ''
         }
-        onChange={(e) => updateHistogramConfig(DIMENSIONS, type, e.target.value)}
+        onChange={(e) => updateHistogramConfig(GROUPBY, type, e.target.value)}
         data-test-subj="valueFieldNumber"
       />
       <EuiSpacer size="s" />
@@ -476,11 +501,10 @@ export const DataConfigPanelItem = ({
     );
   }, [availableFields, configList.span]);
 
-  const getRenderFieldsObj = (sectionName: string, title: string) => {
+  const getRenderFieldsObj = (sectionName: string) => {
     return {
       list: configList[sectionName],
       sectionName,
-      title,
       visType: visualizations.vis.name,
       addButtonText: 'Click to add',
       handleServiceAdd,
@@ -489,7 +513,7 @@ export const DataConfigPanelItem = ({
     };
   };
   return isAddConfigClicked ? (
-    getCommonUI(selectedConfigItem.name === METRICS ? SERIES : 'Dimensions')
+    getCommonUI(selectedConfigItem.name)
   ) : (
     <>
       <EuiTitle size="xxs">
@@ -498,9 +522,9 @@ export const DataConfigPanelItem = ({
       <EuiSpacer size="s" />
       {visualizations.vis.name !== VIS_CHART_TYPES.Histogram ? (
         <>
-          {DataConfigPanelFields(getRenderFieldsObj(METRICS, SERIES))}
+          {DataConfigPanelFields(getRenderFieldsObj(AGGREGATIONS))}
           <EuiSpacer size="s" />
-          {DataConfigPanelFields(getRenderFieldsObj(DIMENSIONS, 'Dimensions'))}
+          {DataConfigPanelFields(getRenderFieldsObj(GROUPBY))}
           <EuiSpacer size="s" />
           <EuiTitle size="xxs">
             <h3>Date Histogram</h3>

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -18,7 +18,6 @@ import {
   EuiSpacer,
   EuiTitle,
   htmlIdGenerator,
-  EuiToolTip,
 } from '@elastic/eui';
 import { batch, useDispatch } from 'react-redux';
 import {
@@ -35,6 +34,7 @@ import { composeAggregations } from '../../../../../../../../common/query_manage
 import {
   ConfigList,
   ConfigListEntry,
+  DataConfigPanelFieldProps,
   DataConfigPanelProps,
 } from '../../../../../../../../common/types/explorer';
 import { TabContext } from '../../../../../hooks';
@@ -501,7 +501,7 @@ export const DataConfigPanelItem = ({
     );
   }, [availableFields, configList.span]);
 
-  const getRenderFieldsObj = (sectionName: string) => {
+  const getRenderFieldsObj = (sectionName: string): DataConfigPanelFieldProps => {
     return {
       list: configList[sectionName],
       sectionName,

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -322,6 +322,7 @@ export const DataConfigPanelItem = ({
       </>
   );
   };
+
   const getCommonDimensionsField = (selectedObj: any, name: string) => (
     <EuiFormRow label="Field">
       <EuiComboBox

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -42,6 +42,7 @@ import { changeQuery } from '../../../../../redux/slices/query_slice';
 import { change as changeVizConfig } from '../../../../../redux/slices/viualization_config_slice';
 import { DataConfigItemClickPanel } from '../config_controls/data_config_item_click_panel';
 import { DataConfigPanelFields } from '../config_controls/data_config_panel_fields';
+import { ButtonGroupItem } from './config_button_group';
 
 const initialDimensionEntry = {
   label: '',
@@ -61,9 +62,6 @@ export const DataConfigPanelItem = ({
   queryManager,
 }: DataConfigPanelProps) => {
   const dispatch = useDispatch();
-<<<<<<< HEAD:dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
-  const { tabId, handleQueryChange, fetchData, curVisId } = useContext<any>(TabContext);
-=======
   const {
     tabId,
     handleQuerySearch,
@@ -73,7 +71,6 @@ export const DataConfigPanelItem = ({
     changeVisualizationConfig,
     curVisId,
   } = useContext<any>(TabContext);
->>>>>>> 9211985 (Made code compatible with PR changes):dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_item.tsx
   const { data } = visualizations;
   const { data: vizData = {}, metadata: { fields = [] } = {} } = data?.rawVizData;
   const {

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
@@ -13,12 +13,16 @@ import {
   EuiSpacer,
   EuiTitle,
 } from '@elastic/eui';
+import { uniqueId } from 'lodash';
+import React, { useContext, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { ConfigTreemapParentFields } from './config_treemap_parents';
 import {
+  CHILDFIELD,
   AGGREGATIONS,
   GROUPBY,
   NUMERICAL_TYPES,
+  PARENTFIELDS,
+  VALUEFIELD,
 } from '../../../../../../../../common/constants/explorer';
 import { DataConfigPanelProps } from '../../../../../../../../common/types/explorer';
 import { TabContext } from '../../../../../hooks';
@@ -100,11 +104,11 @@ export const TreemapConfigPanelItem = ({
 
   const getOptionsAvailable = (sectionName: string) => {
     const { dimensions, series } = configList;
-    let selectedFields = {};
+    const selectedFields = {};
     let allSelectedFields = [];
 
     for (const key in configList) {
-      if (key === 'dimensions') {
+      if (key === GROUPBY) {
         const [dimElements] = dimensions;
         const { childField, parentFields } = dimElements;
         allSelectedFields = [childField, ...parentFields];
@@ -123,7 +127,7 @@ export const TreemapConfigPanelItem = ({
       : unselectedFields;
   };
 
-  const options = getOptionsAvailable(DIMENSIONS).map((opt) => ({
+  const options = getOptionsAvailable(GROUPBY).map((opt) => ({
     label: opt.label,
     name: opt.name,
   }));
@@ -152,7 +156,7 @@ export const TreemapConfigPanelItem = ({
     );
   };
   const handleUpdateParentFields = (arr: ParentUnitType[]) =>
-    updateList(DIMENSIONS, PARENTFIELDS, arr);
+    updateList(GROUPBY, PARENTFIELDS, arr);
 
   const handleParentChange = (values: Array<EuiComboBoxOptionOption<unknown>>) => {
     const selectedAxis = configList.dimensions[0]?.parentFields;
@@ -201,7 +205,7 @@ export const TreemapConfigPanelItem = ({
               }
               singleSelection={{ asPlainText: true }}
               onChange={(val) =>
-                updateList(GROUPBY, 'childField', val.length > 0 ? val[0].label : '')
+                updateList(GROUPBY, CHILDFIELD, val.length > 0 ? val[0].label : '')
               }
             />
           </EuiFormRow>
@@ -216,7 +220,8 @@ export const TreemapConfigPanelItem = ({
               name: opt.label,
             }))}
             selectedAxis={configList.dimensions[0]?.parentFields}
-            onSelectChange={(val) => updateList(GROUPBY, 'parentFields', val)}
+            handleUpdateParentFields={handleUpdateParentFields}
+            setSelectedParentItem={setSelectedParentItem}
           />
           <EuiSpacer size="s" />
         </EuiPanel>
@@ -238,7 +243,7 @@ export const TreemapConfigPanelItem = ({
               }
               singleSelection={{ asPlainText: true }}
               onChange={(val) =>
-                updateList(AGGREGATIONS, 'valueField', val.length > 0 ? val[0].label : '')
+                updateList(AGGREGATIONS, VALUEFIELD, val.length > 0 ? val[0].label : '')
               }
             />
           </EuiFormRow>

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
@@ -12,6 +12,7 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiTitle,
+  htmlIdGenerator,
 } from '@elastic/eui';
 import { uniqueId } from 'lodash';
 import React, { useContext, useEffect, useState } from 'react';
@@ -143,7 +144,7 @@ export const TreemapConfigPanelItem = ({
           closeMenu={() => isHandlePanelClickBack(selectedAxis)}
         />
         <EuiComboBox
-          id={uniqueId('axis-select-')}
+          id={htmlIdGenerator('axis-select-')}
           placeholder="Select a field"
           options={options}
           selectedOptions={selectedAxis[index].label !== '' ? [selectedAxis[index]] : []}

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
@@ -25,7 +25,6 @@ import {
   PARENTFIELDS,
   VALUEFIELD,
 } from '../../../../../../../../common/constants/explorer';
-import { DataConfigPanelProps } from '../../../../../../../../common/types/explorer';
 import { TabContext } from '../../../../../hooks';
 import { ConfigTreemapParentFields } from './config_treemap_parents';
 import { DataConfigItemClickPanel } from './data_config_item_click_panel';
@@ -148,7 +147,7 @@ export const TreemapConfigPanelItem = ({
           placeholder="Select a field"
           options={options}
           selectedOptions={selectedAxis[index].label !== '' ? [selectedAxis[index]] : []}
-          isClearable={true}
+          isClearable
           singleSelection={{ asPlainText: true }}
           onChange={handleParentChange}
           aria-label="Parent field"

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
@@ -17,6 +17,7 @@ import {
 import { uniqueId } from 'lodash';
 import React, { useContext, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { ActionCreatorWithPayload } from '@reduxjs/toolkit';
 import {
   CHILDFIELD,
   AGGREGATIONS,
@@ -32,15 +33,16 @@ import {
   DataConfigPanelProps,
   ParentUnitType,
 } from '../../../../../../../../common/types/explorer';
+import { VIS_CHART_TYPES } from '../../../../../../../../common/constants/shared';
 
 export const TreemapConfigPanelItem = ({
   fieldOptionList,
   visualizations,
 }: DataConfigPanelProps) => {
   const dispatch = useDispatch();
-  const { tabId, curVisId, changeVisualizationConfig, fetchData, handleQueryChange } = useContext<
-    any
-  >(TabContext);
+  const { tabId, curVisId, changeVisualizationConfig } = useContext<{
+    [key: string]: string | VIS_CHART_TYPES | ActionCreatorWithPayload<string, string>;
+  }>(TabContext);
 
   const { data } = visualizations;
   const { userConfigs } = data;
@@ -155,9 +157,12 @@ export const TreemapConfigPanelItem = ({
       </>
     );
   };
+
+  // Below function take input array for dimensions parent fields.
   const handleUpdateParentFields = (arr: ParentUnitType[]) =>
     updateList(GROUPBY, PARENTFIELDS, arr);
 
+  // Below function handle change for input parent fields.
   const handleParentChange = (values: Array<EuiComboBoxOptionOption<unknown>>) => {
     const selectedAxis = configList.dimensions[0]?.parentFields;
     const { index } = selectedParentItem;
@@ -215,10 +220,6 @@ export const TreemapConfigPanelItem = ({
             <h3>Parent Fields</h3>
           </EuiTitle>
           <ConfigTreemapParentFields
-            dropdownList={getOptionsAvailable(GROUPBY).map((opt) => ({
-              label: opt.label,
-              name: opt.label,
-            }))}
             selectedAxis={configList.dimensions[0]?.parentFields}
             handleUpdateParentFields={handleUpdateParentFields}
             setSelectedParentItem={setSelectedParentItem}

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
@@ -158,11 +158,17 @@ export const TreemapConfigPanelItem = ({
     );
   };
 
-  // Below function take input array for dimensions parent fields.
+  /**
+   * Update DataConfiguration of parent fields list.
+   * @param arr list to be updated
+   */
   const handleUpdateParentFields = (arr: ParentUnitType[]) =>
     updateList(GROUPBY, PARENTFIELDS, arr);
 
-  // Below function handle change for input parent fields.
+  /**
+   * function changes the value in parent input field.
+   * @param value updated value
+   */
   const handleParentChange = (values: Array<EuiComboBoxOptionOption<unknown>>) => {
     const selectedAxis = configList.dimensions[0]?.parentFields;
     const { index } = selectedParentItem;
@@ -174,12 +180,16 @@ export const TreemapConfigPanelItem = ({
     handleUpdateParentFields(val);
   };
 
-  const isHandlePanelClickBack = (selectedAxis: ParentUnitType[]) => {
+  /**
+   * Changes the array when back button in Data Config panel is clicked.
+   * @param parentArray updated array of parent fields.
+   */
+  const isHandlePanelClickBack = (parentArray: ParentUnitType[]) => {
     const { index } = selectedParentItem;
-    if (selectedAxis[index].name === '') {
+    if (parentArray[index].name === '') {
       const arr = [
-        ...selectedAxis.slice(0, index),
-        ...selectedAxis.slice(index + 1, selectedAxis.length),
+        ...parentArray.slice(0, index),
+        ...parentArray.slice(index + 1, parentArray.length),
       ];
       handleUpdateParentFields(arr);
     }

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/treemap_config_panel_item.tsx
@@ -6,6 +6,7 @@
 import {
   EuiButton,
   EuiComboBox,
+  EuiComboBoxOptionOption,
   EuiFlexItem,
   EuiFormRow,
   EuiPanel,
@@ -21,10 +22,12 @@ import {
 } from '../../../../../../../../common/constants/explorer';
 import { DataConfigPanelProps } from '../../../../../../../../common/types/explorer';
 import { TabContext } from '../../../../../hooks';
-import { ConfigTreemapParentFields, ParentUnitType } from './config_treemap_parents';
+import { ConfigTreemapParentFields } from './config_treemap_parents';
 import { DataConfigItemClickPanel } from './data_config_item_click_panel';
-import { DataConfigPanelProps } from '../../../../../../../../common/types/explorer';
-
+import {
+  DataConfigPanelProps,
+  ParentUnitType,
+} from '../../../../../../../../common/types/explorer';
 
 export const TreemapConfigPanelItem = ({
   fieldOptionList,
@@ -63,8 +66,7 @@ export const TreemapConfigPanelItem = ({
   }, [userConfigs?.dataConfig, visualizations.vis.name]);
 
   const updateList = (configName: string, fieldName: string, value: string | any[]) => {
-    const list = { ...configList };
-    let listItem = { ...list[configName][0] };
+    let listItem = { ...configList[configName][0] };
 
     const newField = {
       label: value,
@@ -73,7 +75,7 @@ export const TreemapConfigPanelItem = ({
     };
     listItem = { ...listItem, [fieldName]: typeof value === 'string' ? newField : value };
     const newList = {
-      ...list,
+      ...configList,
       [configName]: [listItem],
     };
     setConfigList(newList);
@@ -121,17 +123,10 @@ export const TreemapConfigPanelItem = ({
       : unselectedFields;
   };
 
-  const options = getOptionsAvailable(DIMENSIONS)
-    .map((opt) => ({
-      label: opt.label,
-      name: opt.label,
-    }))
-    .map((item) => {
-      return {
-        ...item,
-        label: item.name,
-      };
-    });
+  const options = getOptionsAvailable(DIMENSIONS).map((opt) => ({
+    label: opt.label,
+    name: opt.name,
+  }));
 
   const renderParentPanel = () => {
     const selectedAxis = configList.dimensions[0]?.parentFields;
@@ -150,10 +145,8 @@ export const TreemapConfigPanelItem = ({
           selectedOptions={selectedAxis[index].label !== '' ? [selectedAxis[index]] : []}
           isClearable={true}
           singleSelection={{ asPlainText: true }}
-          onChange={(option) => {
-            handleParentChange(option);
-          }}
-          aria-label="Use aria labels when no actual label is in use"
+          onChange={handleParentChange}
+          aria-label="Parent field"
         />
       </>
     );
@@ -161,12 +154,12 @@ export const TreemapConfigPanelItem = ({
   const handleUpdateParentFields = (arr: ParentUnitType[]) =>
     updateList(DIMENSIONS, PARENTFIELDS, arr);
 
-  const handleParentChange = (options: Array<EuiComboBoxOptionOption<unknown>>) => {
+  const handleParentChange = (values: Array<EuiComboBoxOptionOption<unknown>>) => {
     const selectedAxis = configList.dimensions[0]?.parentFields;
     const { index } = selectedParentItem;
     const val = [
       ...selectedAxis.slice(0, index),
-      (options[0] as ParentUnitType) ?? initialParentState,
+      (values[0] as ParentUnitType) ?? initialParentState,
       ...selectedAxis.slice(index + 1, selectedAxis.length),
     ];
     handleUpdateParentFields(val);

--- a/dashboards-observability/public/components/visualizations/charts/bar/bar.tsx
+++ b/dashboards-observability/public/components/visualizations/charts/bar/bar.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../../../../common/constants/shared';
 import { AvailabilityUnitType } from '../../../event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_availability';
 import { ThresholdUnitType } from '../../../event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/config_thresholds';
-import { hexToRgb } from '../../../event_analytics/utils/utils';
+import { getPropName, hexToRgb } from '../../../event_analytics/utils/utils';
 import { EmptyPlaceholder } from '../../../event_analytics/explorer/visualizations/shared_components/empty_placeholder';
 import { AGGREGATIONS, GROUPBY } from '../../../../../common/constants/explorer';
 import { IVisualizationContainerProps } from '../../../../../common/types/explorer';
@@ -70,7 +70,9 @@ export const Bar = ({ visualizations, layout, config }: any) => {
         ?.color) ||
     PLOTLY_COLOR[index % PLOTLY_COLOR.length];
 
-  let bars, valueSeries, valueForXSeries;
+  let bars;
+  let valueSeries;
+  let valueForXSeries;
 
   /**
    * determine x axis
@@ -106,8 +108,8 @@ export const Bar = ({ visualizations, layout, config }: any) => {
    * prepare data for visualization, map x-xais to y-xais
    */
   const chartAxis = useMemo(() => {
-    return yaxes[0] && Array.isArray(queriedVizData[`${yaxes[0].aggregation}(${yaxes[0].name})`])
-      ? queriedVizData[`${yaxes[0].aggregation}(${yaxes[0].name})`].map((_, idx) => {
+    return Array.isArray(queriedVizData[getPropName(yaxes[0])])
+      ? queriedVizData[getPropName(yaxes[0])].map((_, idx) => {
           // let combineXaxis = '';
           const xaxisName = xaxes.map((xaxis) => {
             return queriedVizData[xaxis.name] && queriedVizData[xaxis.name][idx]
@@ -121,8 +123,8 @@ export const Bar = ({ visualizations, layout, config }: any) => {
 
   bars = yaxes?.map((yMetric, idx) => {
     return {
-      y: isVertical ? queriedVizData[`${yMetric.aggregation}(${yMetric.name})`] : chartAxis,
-      x: isVertical ? chartAxis : queriedVizData[`${yMetric.aggregation}(${yMetric.name})`],
+      y: isVertical ? queriedVizData[getPropName(yMetric)] : chartAxis,
+      x: isVertical ? chartAxis : queriedVizData[getPropName(yMetric)],
       type: visMetaData.type,
       marker: {
         color: getSelectedColorTheme(yMetric, idx),
@@ -131,7 +133,7 @@ export const Bar = ({ visualizations, layout, config }: any) => {
           width: lineWidth,
         },
       },
-      name: yMetric.name,
+      name: getPropName(yMetric),
       orientation: barOrientation,
     };
   });

--- a/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
+++ b/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
@@ -15,6 +15,7 @@ import { VIS_CHART_TYPES } from '../../../../../common/constants/shared';
 import { QueryManager } from '../../../../../common/query_manager';
 import {
   AGGREGATIONS,
+  CUSTOM_LABEL,
   GROUPBY,
   PARENTFIELDS,
   TIME_INTERVAL_OPTIONS,

--- a/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
+++ b/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
@@ -16,6 +16,7 @@ import { QueryManager } from '../../../../../common/query_manager';
 import {
   AGGREGATIONS,
   GROUPBY,
+  PARENTFIELDS,
   TIME_INTERVAL_OPTIONS,
   CUSTOM_LABEL,
 } from '../../../../../common/constants/explorer';
@@ -140,8 +141,8 @@ const defaultUserConfigs = (queryString, visualizationName: string) => {
     } else if (visualizationName === VIS_CHART_TYPES.HeatMap) {
       tempUserConfigs = {
         ...tempUserConfigs,
-        [GROUPBY]: [initialDimensionEntry, initialDimensionEntry],
-        [AGGREGATIONS]: [initialSeriesEntry],
+        [GROUPBY]: [],
+        [AGGREGATIONS]: [],
       };
     } else {
       tempUserConfigs = {
@@ -175,10 +176,12 @@ const getUserConfigs = (
       case VIS_CHART_TYPES.HeatMap:
         configOfUser = {
           ...userSelectedConfigs,
-          dataConfig: {
-            ...userSelectedConfigs?.dataConfig,
-            ...defaultUserConfigs(query, visName),
-          },
+          dataConfig:
+            userSelectedConfigs?.dataConfig === undefined
+              ? { ...defaultUserConfigs(query, visName) }
+              : {
+                  ...userSelectedConfigs?.dataConfig,
+                },
         };
         break;
       case VIS_CHART_TYPES.TreeMap:
@@ -189,7 +192,11 @@ const getUserConfigs = (
             [GROUPBY]: [
               {
                 childField: { ...(axesData.xaxis ? axesData.xaxis[0] : initialEntryTreemap) },
-                parentFields: [],
+                parentFields:
+                  userSelectedConfigs?.dataConfig !== undefined &&
+                  userSelectedConfigs?.dataConfig[GROUPBY].length > 0
+                    ? [...userSelectedConfigs?.dataConfig[GROUPBY][0][PARENTFIELDS]]
+                    : [],
               },
             ],
             [AGGREGATIONS]: [

--- a/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
+++ b/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
@@ -19,7 +19,6 @@ import {
   GROUPBY,
   PARENTFIELDS,
   TIME_INTERVAL_OPTIONS,
-  CUSTOM_LABEL,
 } from '../../../../../common/constants/explorer';
 interface IVizContainerProps {
   vizId: string;
@@ -195,8 +194,8 @@ const getUserConfigs = (
                 childField: { ...(axesData.xaxis ? axesData.xaxis[0] : initialEntryTreemap) },
                 parentFields:
                   userSelectedConfigs?.dataConfig !== undefined &&
-                  userSelectedConfigs?.dataConfig[GROUPBY]?.length > 0
-                    ? [...userSelectedConfigs?.dataConfig[GROUPBY][0][PARENTFIELDS]]
+                  userSelectedConfigs.dataConfig[GROUPBY]?.length > 0
+                    ? [...userSelectedConfigs.dataConfig[GROUPBY][0][PARENTFIELDS]]
                     : [],
               },
             ],

--- a/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
+++ b/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
@@ -195,7 +195,7 @@ const getUserConfigs = (
                 childField: { ...(axesData.xaxis ? axesData.xaxis[0] : initialEntryTreemap) },
                 parentFields:
                   userSelectedConfigs?.dataConfig !== undefined &&
-                  userSelectedConfigs?.dataConfig[GROUPBY].length > 0
+                  userSelectedConfigs?.dataConfig[GROUPBY]?.length > 0
                     ? [...userSelectedConfigs?.dataConfig[GROUPBY][0][PARENTFIELDS]]
                     : [],
               },

--- a/dashboards-observability/public/components/visualizations/charts/lines/line.tsx
+++ b/dashboards-observability/public/components/visualizations/charts/lines/line.tsx
@@ -14,7 +14,7 @@ import {
   PLOTLY_COLOR,
   VIS_CHART_TYPES,
 } from '../../../../../common/constants/shared';
-import { hexToRgb, getPropName } from '../../../../components/event_analytics/utils/utils';
+import { getPropName, hexToRgb } from '../../../../components/event_analytics/utils/utils';
 import { EmptyPlaceholder } from '../../../event_analytics/explorer/visualizations/shared_components/empty_placeholder';
 import { IVisualizationContainerProps } from '../../../../../common/types/explorer';
 import { AGGREGATIONS, GROUPBY } from '../../../../../common/constants/explorer';

--- a/dashboards-observability/public/components/visualizations/charts/maps/heatmap.tsx
+++ b/dashboards-observability/public/components/visualizations/charts/maps/heatmap.tsx
@@ -2,7 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import React, { useMemo } from 'react';
 import { colorPalette } from '@elastic/eui';
 import { has, isEmpty, uniq } from 'lodash';
 import Plotly from 'plotly.js-dist';
@@ -18,6 +18,8 @@ import {
   getPropName,
 } from '../../../../components/event_analytics/utils/utils';
 import { IVisualizationContainerProps } from '../../../../../common/types/explorer';
+import { EmptyPlaceholder } from '../../../event_analytics/explorer/visualizations/shared_components/empty_placeholder';
+import { Plt } from '../../plotly/plot';
 import { AGGREGATIONS, GROUPBY } from '../../../../../common/constants/explorer';
 
 export const HeatMap = ({ visualizations, layout, config }: any) => {

--- a/dashboards-observability/public/components/visualizations/charts/maps/heatmap.tsx
+++ b/dashboards-observability/public/components/visualizations/charts/maps/heatmap.tsx
@@ -3,17 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useMemo } from 'react';
-import { uniq, has, isEmpty, indexOf } from 'lodash';
-import Plotly from 'plotly.js-dist';
 import { colorPalette } from '@elastic/eui';
-import { Plt } from '../../plotly/plot';
-import { EmptyPlaceholder } from '../../../event_analytics/explorer/visualizations/shared_components/empty_placeholder';
+import { has, isEmpty, uniq } from 'lodash';
+import Plotly from 'plotly.js-dist';
 import {
   HEATMAP_PALETTE_COLOR,
-  SINGLE_COLOR_PALETTE,
-  OPACITY,
   HEATMAP_SINGLE_COLOR,
+  OPACITY,
+  SINGLE_COLOR_PALETTE,
 } from '../../../../../common/constants/colors';
 import {
   hexToRgb,

--- a/dashboards-observability/public/components/visualizations/charts/maps/treemaps.tsx
+++ b/dashboards-observability/public/components/visualizations/charts/maps/treemaps.tsx
@@ -87,10 +87,10 @@ export const TreeMap = ({ visualizations, layout, config }: any) => {
     return <EmptyPlaceholder icon={visMetaData?.icontype} />;
 
   const [treemapData, mergedLayout] = useMemo(() => {
-    let labelsArray: string[] = [],
-      parentsArray: string[] = [],
-      valuesArray: number[] = [],
-      colorsArray: string[] = [];
+    let labelsArray: string[] = [];
+    let parentsArray: string[] = [];
+    let valuesArray: number[] = [];
+    let colorsArray: string[] = [];
 
     if (parentFields.length === 0) {
       labelsArray = [...queriedVizData[childField.name]];

--- a/dashboards-observability/public/components/visualizations/charts/pie/pie.tsx
+++ b/dashboards-observability/public/components/visualizations/charts/pie/pie.tsx
@@ -19,9 +19,7 @@ import {
   PIE_XAXIS_GAP,
   AGGREGATIONS,
   GROUPBY,
-  CUSTOM_LABEL,
 } from '../../../../../common/constants/explorer';
-import { getPropName } from '../../../event_analytics/utils/utils';
 
 export const Pie = ({ visualizations, layout, config }: any) => {
   const {

--- a/dashboards-observability/public/components/visualizations/charts/pie/pie.tsx
+++ b/dashboards-observability/public/components/visualizations/charts/pie/pie.tsx
@@ -19,7 +19,9 @@ import {
   PIE_XAXIS_GAP,
   AGGREGATIONS,
   GROUPBY,
+  CUSTOM_LABEL,
 } from '../../../../../common/constants/explorer';
+import { getPropName } from '../../../event_analytics/utils/utils';
 
 export const Pie = ({ visualizations, layout, config }: any) => {
   const {
@@ -104,7 +106,7 @@ export const Pie = ({ visualizations, layout, config }: any) => {
           labels: labelsOfXAxis,
           values: queriedVizData[fieldName],
           type: 'pie',
-          name: fieldName,
+          name: getPropName(field),
           hole: type === 'pie' ? 0 : 0.5,
           text: fieldName,
           textinfo: 'percent',


### PR DESCRIPTION
### Description
1. Updated UI for Data Configuration Panel referred from https://playground.opensearch.org/app/wizard#/
2. Implemented two-way sync for label
3. Renamed alias to custom label

### Issues Resolved
#1020 
#1038

### Check List
- [ ] New functionality includes a change of Data configuration UI and two-way sync for the custom label.
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
