### PR TITLE
[FEATURE]: Breakdown added in Bar Chart

### DIFF
--- a/dashboards-observability/common/constants/explorer.ts
+++ b/dashboards-observability/common/constants/explorer.ts
@@ -120,7 +120,7 @@ export const AGGREGATION_OPTIONS = [
 ];
 
 // numeric fields type for metrics
-export const numericalTypes = [
+export const NUMERICAL_TYPES = [
   'float',
   'double',
   'bigint',

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -520,8 +520,8 @@ export const DataConfigPanelItem = ({
           </EuiTitle>
           {DateHistogram}
           <EuiSpacer size="s" />
-          {(visualizations.vis.name === visChartTypes.Bar ||
-            visualizations.vis.name === visChartTypes.HorizontalBar) && (
+          {(visualizations.vis.name === VIS_CHART_TYPES.Bar ||
+            visualizations.vis.name === VIS_CHART_TYPES.HorizontalBar) && (
             <>
               <EuiTitle size="xxs">
                 <h3>Breakdowns</h3>

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -519,10 +519,16 @@ export const DataConfigPanelItem = ({
             <h3>Date Histogram</h3>
           </EuiTitle>
           {DateHistogram}
-          {/* <EuiTitle size="xxs">
-            <h3>Breakdowns</h3>
-          </EuiTitle>
-          {Breakdowns} */}
+          <EuiSpacer size="s" />
+          {(visualizations.vis.name === visChartTypes.Bar ||
+            visualizations.vis.name === visChartTypes.HorizontalBar) && (
+            <>
+              <EuiTitle size="xxs">
+                <h3>Breakdowns</h3>
+              </EuiTitle>
+              {Breakdowns}
+            </>
+          )}
         </>
       ) : (
         <>


### PR DESCRIPTION
### Description
Implemented breakdown in bar chart after merging of antlr code.

@mengweieric - the breakdown as of yet has been implemented with the old UI of dropdown. Can change the UI once the PR for updated UI #1046 gets merged to main
<img width="960" alt="breakdown_ui" src="https://user-images.githubusercontent.com/79983862/193076578-c4e070cc-82e9-4900-91c8-71568fe6e623.png">


### Issues Resolved
#849 

### Check List
- [ ] New functionality includes breakdown field added in bar chart.
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
