### PR TITLE
chore: fix line reference

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -14,8 +14,8 @@ By default, tests use the same runtime as `JAVA_HOME`.
 
 ### Setup
 
-1. Download OpenSearch for the version that matches the [OpenSearch Dashboards version specified in opensearch_dashboards.json](./dashboards-observability/opensearch_dashboards.json#L3) from [opensearch.org](https://opensearch.org/downloads.html).
-1. Download the OpenSearch Dashboards source code for the [version specified in opensearch_dashboards.json](./dashboards-observability/opensearch_dashboards.json#L3) you want to set up.
+1. Download OpenSearch for the version that matches the [OpenSearch Dashboards version specified in opensearch_dashboards.json](./dashboards-observability/opensearch_dashboards.json#L4) from [opensearch.org](https://opensearch.org/downloads.html).
+1. Download the OpenSearch Dashboards source code for the [version specified in opensearch_dashboards.json](./dashboards-observability/opensearch_dashboards.json#L4) you want to set up.
 1. Change your node version to the version specified in `.node-version` inside the OpenSearch Dashboards root directory.
 1. cd into `OpenSearch-Dashboards` and remove the `plugins` directory.
 1. Check out this package from version control as the `plugins` directory.


### PR DESCRIPTION
Signed-off-by: derek-ho [dxho@amazon.com](mailto:dxho@amazon.com)

### Description
Fixes the developer guide to refer to the dashboards version: 
https://github.com/opensearch-project/observability/blob/main/dashboards-observability/opensearch_dashboards.json#L4
instead of 
https://github.com/opensearch-project/observability/blob/main/dashboards-observability/opensearch_dashboards.json#L3

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
