### PR TITLE
[BUG]: Visualization Name doesn't appear in selected visualization field in Operational Panel

### DIFF
--- a/dashboards-observability/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
@@ -239,6 +239,7 @@ export const VisaulizationFlyout = ({
               hasNoInitialSelection
               onChange={(e) => onChangeSelection(e)}
               options={visualizationOptions}
+              value={selectValue}
             />
           </EuiFormRow>
           <EuiSpacer size="l" />


### PR DESCRIPTION
Signed-off-by: Vishal Kushwah <vishal.kushwah@domo.com>

### Description
Selected visualization name is showing when selected from the dropdown list 

### Issues Resolved
[#1101](https://github.com/opensearch-project/observability/issues/1101)

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
