### PR TITLE
X-button Bug Fix

### DIFF
--- a/dashboards-observability/common/constants/explorer.ts
+++ b/dashboards-observability/common/constants/explorer.ts
@@ -273,3 +273,4 @@ export const SPAN = 'span';
 export const AGGREGATION_INFO = 'At least one metric is required to render a chart';
 export const DIMENSION_INFO = 'The timestamp type field can be selected as a first dimension only';
 export const TIME_FIELD = 'time_field';
+export const DISABLED_COLOUR = "#fafbfd";

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/logs_view_config_panel_item.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/logs_view_config_panel_item.tsx
@@ -170,6 +170,7 @@ export const LogsViewConfigPanelItem = ({
 
   const getLogsViewUI = () => {
     const list = configList[GROUPBY] ? configList[GROUPBY] : [];
+    const disabledColor = "#fafbfd";
     const listUI = list.map((field, index) => (
       <EuiFormRow
         label="Field"
@@ -177,7 +178,7 @@ export const LogsViewConfigPanelItem = ({
           <EuiText size="xs">
             <EuiIcon
               type="cross"
-              color="danger"
+              color={queriedFields.length === 0 ? "danger" : disabledColor}
               onClick={() => handleServiceRemove(index, GROUPBY)}
             />
           </EuiText>

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/logs_view_config_panel_item.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/logs_view_config_panel_item.tsx
@@ -21,6 +21,7 @@ import {
   AVAILABLE_FIELDS,
   GROUPBY,
   SELECTED_FIELDS,
+  DISABLED_COLOUR
 } from '../../../../../../../../common/constants/explorer';
 import {
   ConfigList,
@@ -170,7 +171,6 @@ export const LogsViewConfigPanelItem = ({
 
   const getLogsViewUI = () => {
     const list = configList[GROUPBY] ? configList[GROUPBY] : [];
-    const disabledColor = "#fafbfd";
     const listUI = list.map((field, index) => (
       <EuiFormRow
         label="Field"
@@ -178,7 +178,7 @@ export const LogsViewConfigPanelItem = ({
           <EuiText size="xs">
             <EuiIcon
               type="cross"
-              color={queriedFields.length === 0 ? "danger" : disabledColor}
+              color={queriedFields.length === 0 ? "danger" : DISABLED_COLOUR}
               onClick={() => handleServiceRemove(index, GROUPBY)}
             />
           </EuiText>


### PR DESCRIPTION
Signed-off-by: Anand6Kumar <anand_kumar6@persistent.com>

### Description
Red cross button appears beside Field title in Data Configurations panel for Logs view when we have stats section in the PPL query is Fixed.

### Issues Resolved
https://github.com/opensearch-project/observability/issues/976

### Check List
- [ ] Bug Fixed for X-button for Log-view map.
- [ ] Commits are signed per the DCO using --signoff
