### PR TITLE
[Feature]: Move Date histogram to dimensions

### DIFF
--- a/dashboards-observability/common/constants/explorer.ts
+++ b/dashboards-observability/common/constants/explorer.ts
@@ -269,3 +269,7 @@ export enum ConfigChartOptionsEnum {
 
 export const CUSTOM_LABEL = 'customLabel';
 export const BREAKDOWNS = 'breakdowns';
+export const SPAN = 'span';
+export const AGGREGATION_INFO = 'At least one metric is required to render a chart';
+export const DIMENSION_INFO = 'The timestamp type field can be selected as a first dimension only';
+export const TIME_FIELD = 'time_field';

--- a/dashboards-observability/common/query_manager/utils/index.ts
+++ b/dashboards-observability/common/query_manager/utils/index.ts
@@ -20,7 +20,8 @@ export const composeAggregations = (
     })),
     groupby: {
       group_fields: aggConfig.dimensions.map((dimension) => ({ name: dimension.name })),
-      span: aggConfig.span ? composeSpan(aggConfig.span) : null,
+      ...(aggConfig.span &&
+        JSON.stringify(aggConfig.span) !== '{}' && { span: composeSpan(aggConfig.span) }),
     },
     partitions: staleStats?.partitions ?? {},
     all_num: staleStats?.all_num ?? {},

--- a/dashboards-observability/common/query_manager/utils/index.ts
+++ b/dashboards-observability/common/query_manager/utils/index.ts
@@ -19,9 +19,9 @@ export const composeAggregations = (
       },
     })),
     groupby: {
-      group_fields: aggConfig.dimensions.map((dimension) => ({ name: dimension.name })),
+      group_fields: aggConfig?.dimensions.map((dimension) => ({ name: dimension.name })),
       ...(aggConfig.span &&
-        JSON.stringify(aggConfig.span) !== '{}' && { span: composeSpan(aggConfig.span) }),
+        JSON.stringify(aggConfig?.span) !== '{}' && { span: composeSpan(aggConfig.span) }),
     },
     partitions: staleStats?.partitions ?? {},
     all_num: staleStats?.all_num ?? {},

--- a/dashboards-observability/common/types/explorer.ts
+++ b/dashboards-observability/common/types/explorer.ts
@@ -46,6 +46,12 @@ export interface IField {
   label?: string;
 }
 
+export interface TimeUnit {
+  name: string;
+  label: string;
+  value: string;
+}
+
 export interface ExplorerFields {
   availableFields: IField[];
   queriedFields: IField[];
@@ -294,9 +300,9 @@ export interface HistogramConfigList {
 }
 
 export interface DimensionSpan {
-  time_field: IField;
+  time_field: IField[];
   interval: number;
-  unit: string;
+  unit: TimeUnit[];
 }
 
 export interface ConfigList {
@@ -352,10 +358,11 @@ export interface TreemapParentsProps {
 
 export interface DataConfigPanelFieldProps {
   list: ConfigListEntry[];
+  dimensionSpan: DimensionSpan;
   sectionName: string;
   visType: VIS_CHART_TYPES;
   addButtonText: string;
   handleServiceAdd: (name: string) => void;
   handleServiceRemove: (index: number, name: string) => void;
-  handleServiceEdit: (isClose: boolean, arrIndex: number, sectionName: string) => void;
+  handleServiceEdit: (arrIndex: number, sectionName: string, isTimeStamp: boolean) => void;
 }

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_panel_fields.tsx
@@ -85,7 +85,7 @@ export const DataConfigPanelFields = ({
             <EuiLink
               role="button"
               tabIndex={0}
-              onClick={() => handleServiceEdit(list.length, GROUPBY, true)}
+              onClick={() => handleServiceEdit(list.length - 1, GROUPBY, true)}
             >
               {`${SPAN}(${time_field[0]?.name}, ${interval} ${unit[0]?.value})`}
             </EuiLink>

--- a/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
+++ b/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
@@ -10,6 +10,7 @@ import {
   GROUPBY,
   PARENTFIELDS,
   SIMILAR_VIZ_TYPES,
+  TIMESTAMP,
   TIME_INTERVAL_OPTIONS,
 } from '../../../../../common/constants/explorer';
 import { VIS_CHART_TYPES } from '../../../../../common/constants/shared';
@@ -21,6 +22,7 @@ import {
   IVisualizationContainerProps,
 } from '../../../../../common/types/explorer';
 import { getVisType } from '../vis_types';
+import { statsChunk } from '../../../../../common/query_manager/ast/types/stats';
 interface IVizContainerProps {
   vizId: string;
   appData?: { fromApp: boolean };
@@ -82,6 +84,30 @@ const getStandardedOuiField = (name?: string, type?: string) => ({
   type,
 });
 
+const getStandardUnitField = (name?: string, value?: string) => ({
+  name,
+  label: name,
+  value,
+});
+
+const getSpanValue = (statsTokens: statsChunk) => {
+  const fieldInfo = statsTokens.groupby?.span?.span_expression?.field;
+  const timeUnit = TIME_INTERVAL_OPTIONS.find(
+    (time_unit) => time_unit.value === statsTokens.groupby?.span?.span_expression?.time_unit
+  );
+  return {
+    span: {
+      time_field: statsTokens.groupby?.span?.span_expression?.field
+        ? [getStandardedOuiField(fieldInfo, TIMESTAMP)]
+        : [],
+      interval: statsTokens.groupby?.span?.span_expression?.literal_value ?? '0',
+      unit: statsTokens.groupby?.span?.span_expression?.time_unit
+        ? [getStandardUnitField(timeUnit?.text, timeUnit?.value)]
+        : [],
+    },
+  };
+};
+
 const defaultUserConfigs = (queryString, visualizationName: string) => {
   let tempUserConfigs = {};
   const qm = new QueryManager();
@@ -92,25 +118,7 @@ const defaultUserConfigs = (queryString, visualizationName: string) => {
       [GROUPBY]: [],
     };
   } else {
-    const fieldInfo = statsTokens.groupby?.span?.span_expression?.field;
-    tempUserConfigs = {
-      span: {
-        time_field: statsTokens.groupby?.span?.span_expression?.field
-          ? [getStandardedOuiField(fieldInfo, 'timestamp')]
-          : [],
-        interval: statsTokens.groupby?.span?.span_expression?.literal_value ?? '0',
-        unit: statsTokens.groupby?.span?.span_expression?.time_unit
-          ? [
-              getStandardedOuiField(
-                TIME_INTERVAL_OPTIONS.find(
-                  (time_unit) =>
-                    time_unit.value === statsTokens.groupby?.span.span_expression.time_unit
-                )?.text
-              ),
-            ]
-          : [],
-      },
-    };
+    tempUserConfigs = { ...(statsTokens.groupby?.span !== null && getSpanValue(statsTokens)) };
     if (visualizationName === VIS_CHART_TYPES.LogsView) {
       const dimensions = statsTokens.aggregations
         .map((agg) => {

--- a/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
+++ b/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
@@ -118,7 +118,11 @@ const defaultUserConfigs = (queryString, visualizationName: string) => {
       [GROUPBY]: [],
     };
   } else {
-    tempUserConfigs = { ...(statsTokens.groupby?.span !== null && getSpanValue(statsTokens)) };
+    tempUserConfigs = {
+      ...(statsTokens.groupby !== '' &&
+        statsTokens.groupby?.span !== null &&
+        getSpanValue(statsTokens)),
+    };
     if (visualizationName === VIS_CHART_TYPES.LogsView) {
       const dimensions = statsTokens.aggregations
         .map((agg) => {


### PR DESCRIPTION
Signed-off-by: harshada.lingayat [harshada_lingayat@persistent.com](mailto:harshada_lingayat@persistent.com)

Description
Moving the date histogram section inside the dimensions panel where it will only render when any timestamp field is selected in the first dimension and once the timestamp is chosen, the option will be removed from the dimensions dropdown.

Issues Resolved
https://github.com/opensearch-project/observability/issues/1079
https://github.com/opensearch-project/observability/issues/1141

![image](https://user-images.githubusercontent.com/60776775/196218661-9add0268-481a-4726-9df9-763bda3dea1a.png)


### Check List
- [ ] New functionality includes moving the date histogram section as a first dimension.
- [ ] Commits are signed per the DCO using --signoff
