### PR TITLE
[BUG]: Overlapping of data in visualization panels 

### DIFF
--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/index.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/index.tsx
@@ -89,9 +89,15 @@ export const ExplorerVisualizations = ({
     }
   };
 
+  const syntheticResize = () => {
+    const event = window.document.createEvent('UIEvents');
+    event.initUIEvent('resize', true, false, window, 0);
+    window.dispatchEvent(event);
+  };
+
   return (
     <div id="vis__mainContent">
-      <EuiResizableContainer>
+      <EuiResizableContainer onPanelWidthChange={syntheticResize}>
         {(EuiResizablePanel, EuiResizableButton) => (
           <>
             <EuiResizablePanel


### PR DESCRIPTION
Signed-off-by: Vishal Kushwah <vishal.kushwah@domo.com>

### Description
When resizing the visualization panel legend text is showing properly.

### Issues Resolved
[1099](https://github.com/opensearch-project/observability/issues/1099)

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
