### PR TITLE
bug fix for Labels on y axis get truncated

### DIFF
--- a/dashboards-observability/public/components/visualizations/charts/lines/line.tsx
+++ b/dashboards-observability/public/components/visualizations/charts/lines/line.tsx
@@ -119,6 +119,7 @@ export const Line = ({ visualizations, layout, config }: any) => {
           titlefont: {
             color: selectedColor,
           },
+          automargin: true,
           tickfont: {
             color: selectedColor,
             ...(labelSize && {


### PR DESCRIPTION
Signed-off-by: SivaprasadAluri <sivaprasad_aluri@persistent.com>

### Description
Fixed Labels on y axis get truncated

### Issues Resolved
[BUG] Labels on y axis get truncated https://github.com/opensearch-project/observability/issues/1107
