### PR TITLE
Fix 'getName is not a function' issue for query manager

### DIFF
--- a/dashboards-observability/common/query_manager/ast/builder/stats_ast_builder.ts
+++ b/dashboards-observability/common/query_manager/ast/builder/stats_ast_builder.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { isFunction, isEqual } from 'lodash';
 import { AbstractParseTreeVisitor } from 'antlr4ts/tree/AbstractParseTreeVisitor';
 import {
   RootContext,
@@ -49,13 +50,16 @@ export class StatsAstBuilder
 
   visitRoot(ctx: RootContext) {
     if (!ctx.pplStatement()) return this.defaultResult();
-    return this.visitChildren(ctx.pplStatement()!);
+    return this.visitPplStatement(ctx.pplStatement()!);
   }
 
   visitPplStatement(ctx: PplStatementContext): PPLNode {
     let statsTree: VisitResult = this.defaultResult();
     ctx.commands().map((pplCommandContext) => {
-      if (this.visitChildren(pplCommandContext).getName() === 'stats_command')
+      if (
+        isFunction(this.visitChildren(pplCommandContext).getName) &&
+        isEqual(this.visitChildren(pplCommandContext).getName(), 'stats_command')
+      )
         statsTree = this.visitChildren(pplCommandContext);
     });
     return statsTree;

--- a/dashboards-observability/common/query_manager/ast/builder/stats_builder.ts
+++ b/dashboards-observability/common/query_manager/ast/builder/stats_builder.ts
@@ -22,13 +22,13 @@ import {
   StatsAggregationFunctionChunk,
   GroupByChunk,
   GroupField,
-  statsChunk,
+  StatsChunk,
   SpanExpressionChunk,
 } from '../types';
 import { CUSTOM_LABEL } from '../../../../common/constants/explorer';
 
 export class StatsBuilder implements QueryBuilder<Aggregations> {
-  constructor(private statsChunk: statsChunk) {}
+  constructor(private statsChunk: StatsChunk) {}
 
   build(): Aggregations {
     // return a new stats subtree

--- a/dashboards-observability/common/query_manager/ast/types/index.ts
+++ b/dashboards-observability/common/query_manager/ast/types/index.ts
@@ -10,7 +10,7 @@ export {
   StatsAggregationFunctionChunk,
   GroupByChunk,
   GroupField,
-  statsChunk,
+  StatsChunk,
   SpanExpressionChunk,
   AggregationConfigurations,
   PreviouslyParsedStaleStats


### PR DESCRIPTION
### Description
Fix 'getName is not a function' issue

### Issues Resolved
#1042 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
