### PR TITLE
[Bug]: Fixed histogram update chart reset values issue.

### DIFF
--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -430,6 +430,7 @@ export const DataConfigPanelItem = ({
         }
         onChange={(e) => updateHistogramConfig(GROUPBY, type, e.target.value)}
         data-test-subj="valueFieldNumber"
+        min={0}
       />
       <EuiSpacer size="s" />
     </>

--- a/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
+++ b/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
@@ -222,9 +222,9 @@ const getUserConfigs = (
         configOfUser = {
           ...userSelectedConfigs,
           dataConfig: {
-            ...userSelectedConfigs?.dataConfig,
             [GROUPBY]: [{ bucketSize: '', bucketOffset: '' }],
             [AGGREGATIONS]: [],
+            ...userSelectedConfigs?.dataConfig,
           },
         };
         break;


### PR DESCRIPTION
Signed-off-by: Saisanju Sreevalsakumar <saisanju_s@persistent.com>

### Description
Histogram values sets to empty after clicking on update chart

### Issues Resolved
https://github.com/opensearch-project/observability/issues/1144

### Check List
- [ ] New functionality includes fix for histogram values setting to empty on update chart click.
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
