### PR TITLE
[BUG] : Labels on y axis get truncated 

### DIFF
--- a/dashboards-observability/public/components/visualizations/charts/lines/line.tsx
+++ b/dashboards-observability/public/components/visualizations/charts/lines/line.tsx
@@ -119,6 +119,7 @@ export const Line = ({ visualizations, layout, config }: any) => {
           titlefont: {
             color: selectedColor,
           },
+          automargin: true,
           tickfont: {
             color: selectedColor,
             ...(labelSize && {

--- a/dashboards-observability/public/components/visualizations/charts/maps/heatmap.tsx
+++ b/dashboards-observability/public/components/visualizations/charts/maps/heatmap.tsx
@@ -144,6 +144,7 @@ export const HeatMap = ({ visualizations, layout, config }: any) => {
     },
   ];
 
+  layout.yaxis = { autosize: true, automargin: true };
   const mergedLayout = {
     ...layout,
     ...(layoutConfig.layout && layoutConfig.layout),


### PR DESCRIPTION
### Description
fixed the Labels on y axis get truncated

### Issues Resolved
[BUG] Labels on y axis get truncated (https://github.com/opensearch-project/observability/issues/1107)

