### PR TITLE
[BUG]: Fixed Consolidated UI issues 

### DIFF
--- a/dashboards-observability/public/components/event_analytics/explorer/explorer.scss
+++ b/dashboards-observability/public/components/event_analytics/explorer/explorer.scss
@@ -8,7 +8,7 @@
 }
 
 .liveStream {
-  margin : 8px;
+  margin: 8px;
   height: 40px;
   align-items: center;
   justify-content: center;
@@ -21,7 +21,7 @@
 .mainContentTabs .euiResizableContainer {
   height: calc(100vh - 298px);
 }
-  
+
 .data_config_resizable_btn {
   margin-left: 2px !important;
 }
@@ -31,5 +31,5 @@
 }
 
 .ws__configPanel--right {
-  border-left: 1px solid #D3DAE6 !important;
+  border-left: 1px solid #d3dae6 !important;
 }

--- a/dashboards-observability/public/components/event_analytics/explorer/explorer.scss
+++ b/dashboards-observability/public/components/event_analytics/explorer/explorer.scss
@@ -22,3 +22,14 @@
   height: calc(100vh - 298px);
 }
   
+.data_config_resizable_btn {
+  margin-left: 2px !important;
+}
+
+.chart_style_resizable_btn {
+  margin-right: 2px !important;
+}
+
+.ws__configPanel--right {
+  border-left: 1px solid #D3DAE6 !important;
+}

--- a/dashboards-observability/public/components/event_analytics/explorer/explorer.scss
+++ b/dashboards-observability/public/components/event_analytics/explorer/explorer.scss
@@ -21,15 +21,3 @@
 .mainContentTabs .euiResizableContainer {
   height: calc(100vh - 298px);
 }
-
-.data_config_resizable_btn {
-  margin-left: 2px !important;
-}
-
-.chart_style_resizable_btn {
-  margin-right: 2px !important;
-}
-
-.ws__configPanel--right {
-  border-left: 1px solid #d3dae6;
-}

--- a/dashboards-observability/public/components/event_analytics/explorer/explorer.scss
+++ b/dashboards-observability/public/components/event_analytics/explorer/explorer.scss
@@ -31,5 +31,5 @@
 }
 
 .ws__configPanel--right {
-  border-left: 1px solid #d3dae6 !important;
+  border-left: 1px solid #d3dae6;
 }

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panel.scss
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panel.scss
@@ -168,6 +168,18 @@ $vis-editor-sidebar-min-width: 350px;
   overflow-y: unset; // unset default setting
 }
 
+#vis__mainContent .data_config_resizable_btn {
+  margin-left: 3px;
+}
+
+#vis__mainContent .chart_style_resizable_btn {
+  margin-right: 3px;
+}
+
+#vis__mainContent .ws__configPanel--right {
+  border-left: 1px solid #d3dae6;
+}
+
 .panelItem_button {
   display: grid;
   grid-template-columns: 1fr auto;

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_item_click_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_item_click_panel.tsx
@@ -19,12 +19,7 @@ export interface TitleProps {
 
 export const DataConfigItemClickPanel = ({ title, isSecondary, closeMenu }: TitleProps) => {
   const icon = isSecondary && (
-    <EuiIcon
-      style={{ cursor: 'pointer' }}
-      type="arrowLeft"
-      onClick={closeMenu}
-      data-test-subj="panelCloseBtn"
-    />
+    <EuiIcon style={{ cursor: 'pointer' }} type="arrowLeft" onClick={closeMenu} data-test-subj="panelCloseBtn"/>
   );
   return (
     <>

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_item_click_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_item_click_panel.tsx
@@ -20,10 +20,11 @@ export interface TitleProps {
 export const DataConfigItemClickPanel = ({ title, isSecondary, closeMenu }: TitleProps) => {
   const icon = isSecondary && (
     <EuiIcon
-    style={{cursor:'pointer'}}
-     type="arrowLeft" 
-     onClick={closeMenu} 
-     data-test-subj="panelCloseBtn" />
+      style={{ cursor: 'pointer' }}
+      type="arrowLeft"
+      onClick={closeMenu}
+      data-test-subj="panelCloseBtn"
+    />
   );
   return (
     <>

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_item_click_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_config_item_click_panel.tsx
@@ -19,7 +19,11 @@ export interface TitleProps {
 
 export const DataConfigItemClickPanel = ({ title, isSecondary, closeMenu }: TitleProps) => {
   const icon = isSecondary && (
-    <EuiIcon type="arrowLeft" onClick={closeMenu} data-test-subj="panelCloseBtn" />
+    <EuiIcon
+    style={{cursor:'pointer'}}
+     type="arrowLeft" 
+     onClick={closeMenu} 
+     data-test-subj="panelCloseBtn" />
   );
   return (
     <>

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -393,6 +393,7 @@ export const DataConfigPanelItem = ({
             aria-label="input field"
             placeholder="Select a field"
             singleSelection={{ asPlainText: true }}
+            isClearable={false}
             options={getOptionsAvailable(name)}
             selectedOptions={
               isTimeStampSelected

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -466,7 +466,7 @@ export const DataConfigPanelItem = ({
                 <EuiComboBox
                   aria-label="date unit"
                   placeholder="Select fields"
-                  singleSelection={{asPlainText:true}}
+                  singleSelection={{ asPlainText: true }}
                   isClearable={false}
                   options={TIME_INTERVAL_OPTIONS.map((option) => {
                     return {

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -466,7 +466,8 @@ export const DataConfigPanelItem = ({
                 <EuiComboBox
                   aria-label="date unit"
                   placeholder="Select fields"
-                  singleSelection
+                  singleSelection={{asPlainText:true}}
+                  isClearable={false}
                   options={TIME_INTERVAL_OPTIONS.map((option) => {
                     return {
                       ...option,

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/index.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/index.tsx
@@ -128,7 +128,7 @@ export const ExplorerVisualizations = ({
                 <div className="explorer__vizDataConfig">{renderDataConfigContainer()}</div>
               </div>
             </EuiResizablePanel>
-            <EuiResizableButton />
+            <EuiResizableButton className="data_config_resizable_btn" />
             <EuiResizablePanel
               className="ws__central--canvas"
               initialSize={60}
@@ -142,13 +142,14 @@ export const ExplorerVisualizations = ({
                 visualizations={visualizations}
               />
             </EuiResizablePanel>
-            <EuiResizableButton />
+            <EuiResizableButton  className='chart_style_resizable_btn'/>
             <EuiResizablePanel
               className="ws__configPanel--right"
               initialSize={20}
               minSize="15%"
               mode={['collapsible', { position: 'top' }]}
               paddingSize="none"
+              
             >
               <ConfigPanel
                 vizVectors={explorerVis}

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/index.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/index.tsx
@@ -142,14 +142,13 @@ export const ExplorerVisualizations = ({
                 visualizations={visualizations}
               />
             </EuiResizablePanel>
-            <EuiResizableButton  className='chart_style_resizable_btn'/>
+            <EuiResizableButton className="chart_style_resizable_btn" />
             <EuiResizablePanel
               className="ws__configPanel--right"
               initialSize={20}
               minSize="15%"
               mode={['collapsible', { position: 'top' }]}
               paddingSize="none"
-              
             >
               <ConfigPanel
                 vizVectors={explorerVis}

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/workspace_panel/workspace_panel.scss
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/workspace_panel/workspace_panel.scss
@@ -20,6 +20,6 @@
 }
 
 #vis__mainContent .ws__central--canvas {
-  background-color: #FFF;
+  background-color: #fff;
   // border-right: 1px solid #D3DAE6;
 }

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/workspace_panel/workspace_panel.scss
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/workspace_panel/workspace_panel.scss
@@ -21,5 +21,5 @@
 
 #vis__mainContent .ws__central--canvas {
   background-color: #FFF;
-  border-right: 1px solid #D3DAE6;
+  // border-right: 1px solid #D3DAE6;
 }

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/workspace_panel/workspace_panel.scss
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/workspace_panel/workspace_panel.scss
@@ -21,5 +21,5 @@
 
 #vis__mainContent .ws__central--canvas {
   background-color: #fff;
-  // border-right: 1px solid #D3DAE6;
+  
 }


### PR DESCRIPTION
    Description
1. Back option in series and dimensions have an arrow head in place of hand pointer.
2. Single select dropdowns in Unit Dropdown & Timestamp looks like multiselect dropdowns.
3. The resize button on chart visualization panel overlaps with the border.

   Issues Resolved
- Back option in series and dimensions now have an arrow head
- Unit Dropdown & Timestamp have single select dropdowns
- Resize button on either side of the panel is not overlapping now. 
 
   Check List 
- [ ] Commits are signed per the DCO using --signoff


