### PR TITLE
[UI improvement] Data config update button is hidden if user needs to scroll

### DIFF
--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.scss
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.scss
@@ -11,19 +11,18 @@
   border-right: $euiBorderThin;
   position: relative;
 
-  .euiConfigPanel {
+  .configPanel {
     height: 100%;
     display: flex;
     flex-direction: column;
 
-    .euiPanelFields {
+    .configPanelFields {
       @include euiYScrollWithShadows;
       height: 90%;
       overflow-y: scroll;
     }
 
-    .euiFlexUpdateButton {
-      position: absolute;
+    .updateButtonContainer {
       width: 80%;
       bottom: 0;
       display: flex;
@@ -31,7 +30,7 @@
       justify-content: center;
       padding: 0 0 5px 10%;
 
-      .euiUpdateButton {
+      .updateButton {
         width: 100%;
       }
     }

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.scss
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.scss
@@ -3,17 +3,40 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-.euiConfigPanel {
-  display: flex;
-  flex-direction: column;
-}
-
-.euiScrollSection {
+.explorer__vizDataConfig {
   @include euiYScrollWithShadows;
 
+  background: $euiColorLightestShade;
+  border-left: $euiBorderThin;
+  border-right: $euiBorderThin;
   position: relative;
-  max-height: 300px;
-  overflow-y: auto;
+
+  .euiConfigPanel {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+
+    .euiPanelFields {
+      @include euiYScrollWithShadows;
+      height: 90%;
+      overflow-y: scroll;
+    }
+
+    .euiFlexUpdateButton {
+      position: absolute;
+      width: 80%;
+      bottom: 0;
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+      padding: 0 0 5px 10%;
+
+      .euiUpdateButton {
+        width: 100%;
+      }
+    }
+
+  }
 
   &__section {
     width: 100%;
@@ -43,7 +66,7 @@
     left: 100%;
   }
 
-  &.showSecondary > .wizConfig__section {
+  &.showSecondary>.wizConfig__section {
     transform: translateX(-100%);
   }
 }

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.scss
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.scss
@@ -18,7 +18,7 @@
 
     .configPanelFields {
       @include euiYScrollWithShadows;
-      height: 90%;
+      height: 100%;
       overflow-y: scroll;
     }
 
@@ -65,7 +65,7 @@
     left: 100%;
   }
 
-  &.showSecondary>.wizConfig__section {
+  &.showSecondary > .wizConfig__section {
     transform: translateX(-100%);
   }
 }

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.scss
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.scss
@@ -3,13 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-.explorer__vizDataConfig {
+.euiConfigPanel {
+  display: flex;
+  flex-direction: column;
+}
+
+.euiScrollSection {
   @include euiYScrollWithShadows;
 
-  background: $euiColorLightestShade;
-  border-left: $euiBorderThin;
-  border-right: $euiBorderThin;
   position: relative;
+  max-height: 300px;
+  overflow-y: auto;
 
   &__section {
     width: 100%;

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -526,8 +526,8 @@ export const DataConfigPanelItem = ({
   return isAddConfigClicked ? (
     getCommonUI(selectedConfigItem.name)
   ) : (
-    <div className='euiConfigPanel'>
-      <div className='euiPanelFields'>
+    <div className='configPanel'>
+      <div className='configPanelFields'>
         <EuiTitle size="xxs">
           <h3>Configuration</h3>
         </EuiTitle>
@@ -561,8 +561,8 @@ export const DataConfigPanelItem = ({
         </EuiFlexItem>
         <EuiSpacer size="m" />
       </div>
-      <EuiFlexItem grow={false} className="euiFlexUpdateButton">
-        <EuiButton className='euiUpdateButton'
+      <EuiFlexItem grow={false} className="updateButtonContainer">
+        <EuiButton className='updateButton'
           data-test-subj="visualizeEditorRenderButton"
           iconType="play"
           onClick={() => updateChart()}

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -527,12 +527,12 @@ export const DataConfigPanelItem = ({
     getCommonUI(selectedConfigItem.name)
   ) : (
     <div className='euiConfigPanel'>
-      <>
+      <div className='euiPanelFields'>
         <EuiTitle size="xxs">
           <h3>Configuration</h3>
         </EuiTitle>
         <EuiSpacer size="s" />
-        <EuiFlexItem grow={false} className="euiScrollSection">
+        <EuiFlexItem grow={false}>
           {visualizations.vis.name !== VIS_CHART_TYPES.Histogram ? (
             <>
               {DataConfigPanelFields(getRenderFieldsObj(AGGREGATIONS))}
@@ -560,9 +560,9 @@ export const DataConfigPanelItem = ({
           )}
         </EuiFlexItem>
         <EuiSpacer size="m" />
-      </>
-      <EuiFlexItem grow={false}>
-        <EuiButton
+      </div>
+      <EuiFlexItem grow={false} className="euiFlexUpdateButton">
+        <EuiButton className='euiUpdateButton'
           data-test-subj="visualizeEditorRenderButton"
           iconType="play"
           onClick={() => updateChart()}

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -161,12 +161,12 @@ export const DataConfigPanelItem = ({
       [name]:
         name !== `${BREAKDOWNS}`
           ? [
-              ...(configList[name] ?? []),
-              name === AGGREGATIONS ? initialSeriesEntry : initialDimensionEntry,
-            ]
+            ...(configList[name] ?? []),
+            name === AGGREGATIONS ? initialSeriesEntry : initialDimensionEntry,
+          ]
           : configList[name] !== undefined
-          ? [...configList[name], initialDimensionEntry]
-          : [initialDimensionEntry],
+            ? [...configList[name], initialDimensionEntry]
+            : [initialDimensionEntry],
     };
     setSelectedConfigItem({ index: list[name].length - 1, name });
     setConfigList(list);
@@ -350,10 +350,10 @@ export const DataConfigPanelItem = ({
                     selectedOptions={
                       selectedObj.aggregation
                         ? [
-                            {
-                              label: selectedObj.aggregation,
-                            },
-                          ]
+                          {
+                            label: selectedObj.aggregation,
+                          },
+                        ]
                         : []
                     }
                     onChange={(e) => updateList(e.length > 0 ? e[0].label : '', 'aggregation')}
@@ -397,9 +397,9 @@ export const DataConfigPanelItem = ({
       [SPAN]:
         configList[SPAN] === undefined
           ? {
-              ...initialSpanEntry,
-              [field]: value,
-            }
+            ...initialSpanEntry,
+            [field]: value,
+          }
           : { ...configList[SPAN], [field]: value },
     };
     if (field === TIME_FIELD && index > -1) {
@@ -423,12 +423,12 @@ export const DataConfigPanelItem = ({
               isTimeStampSelected
                 ? [...configList.span?.time_field]
                 : selectedObj?.label
-                ? [
+                  ? [
                     {
                       label: selectedObj?.label,
                     },
                   ]
-                : []
+                  : []
             }
             onChange={(e) =>
               isTimeStampFieldsSelected(e.length > 0 ? e[0].label : '')
@@ -526,38 +526,41 @@ export const DataConfigPanelItem = ({
   return isAddConfigClicked ? (
     getCommonUI(selectedConfigItem.name)
   ) : (
-    <>
-      <EuiTitle size="xxs">
-        <h3>Configuration</h3>
-      </EuiTitle>
-      <EuiSpacer size="s" />
-      {visualizations.vis.name !== VIS_CHART_TYPES.Histogram ? (
-        <>
-          {DataConfigPanelFields(getRenderFieldsObj(AGGREGATIONS))}
-          <EuiSpacer size="s" />
-          {DataConfigPanelFields(getRenderFieldsObj(GROUPBY))}
-          <EuiSpacer size="s" />
-          {(visualizations.vis.name === VIS_CHART_TYPES.Bar ||
-            visualizations.vis.name === VIS_CHART_TYPES.HorizontalBar ||
-            visualizations.vis.name === VIS_CHART_TYPES.Line) && (
-            <>{DataConfigPanelFields(getRenderFieldsObj(BREAKDOWNS))}</>
-          )}
-        </>
-      ) : (
-        <>
-          <EuiTitle size="xxs">
-            <h3>Bucket Size</h3>
-          </EuiTitle>
-          {getNumberField('bucketSize')}
+    <div className='euiConfigPanel'>
+      <>
+        <EuiTitle size="xxs">
+          <h3>Configuration</h3>
+        </EuiTitle>
+        <EuiSpacer size="s" />
+        <EuiFlexItem grow={false} className="euiScrollSection">
+          {visualizations.vis.name !== VIS_CHART_TYPES.Histogram ? (
+            <>
+              {DataConfigPanelFields(getRenderFieldsObj(AGGREGATIONS))}
+              <EuiSpacer size="s" />
+              {DataConfigPanelFields(getRenderFieldsObj(GROUPBY))}
+              <EuiSpacer size="s" />
+              {(visualizations.vis.name === VIS_CHART_TYPES.Bar ||
+                visualizations.vis.name === VIS_CHART_TYPES.HorizontalBar) && (
+                  <>{DataConfigPanelFields(getRenderFieldsObj(BREAKDOWNS))}</>
+                )}
+            </>
+          ) : (
+            <>
+              <EuiTitle size="xxs">
+                <h3>Bucket Size</h3>
+              </EuiTitle>
+              {getNumberField('bucketSize')}
 
-          <EuiSpacer size="s" />
-          <EuiTitle size="xxs">
-            <h3>Bucket Offset</h3>
-          </EuiTitle>
-          {getNumberField('bucketOffset')}
-        </>
-      )}
-      <EuiSpacer size="m" />
+              <EuiSpacer size="s" />
+              <EuiTitle size="xxs">
+                <h3>Bucket Offset</h3>
+              </EuiTitle>
+              {getNumberField('bucketOffset')}
+            </>
+          )}
+        </EuiFlexItem>
+        <EuiSpacer size="m" />
+      </>
       <EuiFlexItem grow={false}>
         <EuiButton
           data-test-subj="visualizeEditorRenderButton"
@@ -568,6 +571,6 @@ export const DataConfigPanelItem = ({
           Update chart
         </EuiButton>
       </EuiFlexItem>
-    </>
+    </div>
   );
 };


### PR DESCRIPTION
### Description
Data config update chart button is visible at the bottom without scrolling.

### Issues Resolved
opensearch-project/dashboards-observability#55 

### Check List
- [ ] Implemented improvement in Update Chart Button
- [ ] Commits are signed per the DCO using --signoff
