### PR TITLE
Fix bugs in patterns

### DIFF
--- a/dashboards-observability/public/components/event_analytics/explorer/explorer.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/explorer.tsx
@@ -1075,6 +1075,7 @@ export const Explorer = ({
         isIndexPatternChanged(tempQuery, query[RAW_QUERY])
       ) {
         await updateCurrentTimeStamp('');
+        await setDefaultPatternsField('', '');
       }
       if (availability !== true) {
         await updateQueryInStore(tempQuery);

--- a/dashboards-observability/public/components/event_analytics/explorer/explorer.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/explorer.tsx
@@ -611,7 +611,9 @@ export const Explorer = ({
     if (currQuery.match(PPL_PATTERNS_REGEX)) {
       currQuery = currQuery.replace(PPL_PATTERNS_REGEX, '');
     }
-    const patternSelectQuery = `${currQuery.trim()} | patterns ${currPattern} | where patterns_field = '${pattern}'`;
+    const patternSelectQuery =
+      `${currQuery.trim()} | patterns \`${currPattern}\` | ` +
+      `where patterns_field = '${pattern.replaceAll("'", "''")}'`;
     // Passing in empty string will remove pattern query
     const newQuery = pattern ? patternSelectQuery : currQuery;
     await setTempQuery(newQuery);

--- a/dashboards-observability/public/components/event_analytics/hooks/use_fetch_patterns.ts
+++ b/dashboards-observability/public/components/event_analytics/hooks/use_fetch_patterns.ts
@@ -91,14 +91,10 @@ export const useFetchPatterns = ({ pplService, requestParams }: IFetchPatternsPa
 
   const setDefaultPatternsField = async (
     index: string,
-    pattern: string,
-    errorHandler: (error: any) => void
+    patternField: string,
+    errorHandler?: (error: any) => void
   ) => {
-    let patternField = pattern;
-    if (!pattern) {
-      if (!index) {
-        return;
-      }
+    if (!patternField && index) {
       const query = `source = ${index} | head 1`;
       await fetchEvents(
         { query },
@@ -122,7 +118,7 @@ export const useFetchPatterns = ({ pplService, requestParams }: IFetchPatternsPa
       );
     }
     // Set pattern to the pattern passed in or the default pattern field found if pattern is empty
-    await dispatch(
+    dispatch(
       changeQuery({
         tabId: requestParams.tabId,
         query: {


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
1. Escape single quotes
To make this work:
```json5
POST test/_doc
{
  "message": "!@#$%^&*()_+-={}|\\[];':\",.<>",
  "timestamp": "2022-11-02T16:47:24Z"
}
```
query should use `''` for single quotes
```
source = test | patterns `message` | where patterns_field = '!@#$%^&*()_+-={}|\[];'':",.<>'
```

2. Refresh pattern when index changes

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
