### PR TITLE
[Metrics][Fix] Correct url to custom-panels on Metrics page fetch.

### DIFF
--- a/dashboards-observability/public/components/metrics/helpers/utils.tsx
+++ b/dashboards-observability/public/components/metrics/helpers/utils.tsx
@@ -57,7 +57,7 @@ export const pplServiceRequestor = (pplService: PPLService, finalQuery: string) 
 
 // Observability backend to fetch visualizations/custom metrics
 export const getVisualizations = (http: CoreStart['http']) => {
-  return http.get(`${CUSTOM_PANELS_API_PREFIX}/visualizations/`).catch((err) => {
+  return http.get(`${CUSTOM_PANELS_API_PREFIX}/visualizations`).catch((err) => {
     console.error('Issue in fetching all saved visualizations', err);
   });
 };


### PR DESCRIPTION
Signed-off-by: Peter Fitzgibbons <pjfitz@amazon.com>

### Description
Fix fetch error on custom panels in Metrics Explorer

### Issues Resolved


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
