### PR TITLE
Add Rupal, Derek, Lior as maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,5 +7,8 @@
 | Eric Wei      | [mengweieric](https://github.com/mengweieric)   | Amazon      |
 | Joshua Li     | [joshuali925](https://github.com/joshuali925)   | Amazon      |
 | Shenoy Pratik | [ps48](https://github.com/ps48)                 | Amazon      |
-| Kavitha Mohan | [kavithacm] (https://github.com/kavithacm)      | Amazon      |
-| Eugene Lee    | [eugenesk24] (https://github.com/eugenesk24)    | Amazon      |
+| Kavitha Mohan | [kavithacm](https://github.com/kavithacm)       | Amazon      |
+| Eugene Lee    | [eugenesk24](https://github.com/eugenesk24)     | Amazon      |
+| Rupal Mahajan | [rupal-bq](https://github.com/rupal-bq)         | Amazon      |
+| Derek Ho      | [derek-ho](https://github.com/derek-ho)         | Amazon      |
+| Lior Perry    | [YANG-DB](https://github.com/YANG-DB)           | Amazon      |


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Following https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md#addition to update maintainer list with nominees. The maintainers have voted and agreed to this nomination and the nominee confirmed their interest in becoming co-maintainer.

@anirudha could you also give them maintainer access to this repo

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
