### PR TITLE
Use in-memory count for total hits in patterns ratio

### DIFF
--- a/dashboards-observability/public/components/event_analytics/explorer/explorer.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/explorer.tsx
@@ -879,11 +879,6 @@ export const Explorer = ({
                             tabId={tabId}
                             query={query}
                             isPatternLoading={isPatternLoading}
-                            totalHits={reduce(
-                              countDistribution.data['count()'],
-                              (sum, n) => sum + n,
-                              0
-                            )}
                           />
                           <EuiHorizontalRule margin="xs" />
                         </>

--- a/dashboards-observability/public/components/event_analytics/explorer/log_patterns/patterns_table.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/log_patterns/patterns_table.tsx
@@ -25,13 +25,11 @@ interface PatternsTableProps {
   tabId: string;
   query: any;
   isPatternLoading: boolean;
-  totalHits?: number;
 }
 
 export function PatternsTable(props: PatternsTableProps) {
-  const { tableData, tabId, onPatternSelection, query } = props;
-  const patternsData = useSelector(selectPatterns)[tabId];
-  const totalHits = props.totalHits || tableData.reduce((p, v) => p + v.count, 0);
+  const { tableData, onPatternSelection, query } = props;
+  const totalHits = tableData.reduce((p, v) => p + v.count, 0);
 
   const tableColumns = [
     {


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Patterns was using total hits from hits counter since prometheus doesn't support `stats count()`, but hits counter will refresh if filtered by pattern, and the ratio becomes incorrect.

### Issues Resolved
closes #1251 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
