### PR TITLE
Add metrics framework for frontend and backend

### DIFF
--- a/dashboards-observability/public/components/app.tsx
+++ b/dashboards-observability/public/components/app.tsx
@@ -4,20 +4,21 @@
  */
 
 import { I18nProvider } from '@osd/i18n/react';
+import { QueryManager } from 'common/query_manager';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { HashRouter, Route, Switch } from 'react-router-dom';
-import { QueryManager } from 'common/query_manager';
 import { CoreStart } from '../../../../src/core/public';
 import { observabilityID, observabilityTitle } from '../../common/constants/shared';
 import store from '../framework/redux/store';
 import { AppPluginStartDependencies } from '../types';
 import { Home as ApplicationAnalyticsHome } from './application_analytics/home';
+import { MetricsListener } from './common/metrics_listener';
 import { Home as CustomPanelsHome } from './custom_panels/home';
 import { EventAnalytics } from './event_analytics';
+import { Home as MetricsHome } from './metrics/index';
 import { Main as NotebooksHome } from './notebooks/components/main';
 import { Home as TraceAnalyticsHome } from './trace_analytics/home';
-import { Home as MetricsHome } from './metrics/index';
 
 interface ObservabilityAppDeps {
   CoreStartProp: CoreStart;
@@ -58,7 +59,7 @@ export const App = ({
     <Provider store={store}>
       <HashRouter>
         <I18nProvider>
-          <>
+          <MetricsListener http={http}>
             <Switch>
               <Route
                 path="/metrics_analytics/"
@@ -160,7 +161,7 @@ export const App = ({
                 }}
               />
             </Switch>
-          </>
+          </MetricsListener>
         </I18nProvider>
       </HashRouter>
     </Provider>

--- a/dashboards-observability/public/components/common/metrics_listener.tsx
+++ b/dashboards-observability/public/components/common/metrics_listener.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { HttpStart } from '../../../../../src/core/public';
+import { OBSERVABILITY_BASE } from '../../../common/constants/shared';
+
+interface MetricsListenerProps {
+  http: HttpStart;
+}
+
+export const MetricsListener: React.FC<MetricsListenerProps> = (props) => {
+  const incrementCountMetric = (element: string) => {
+    props.http.post(`${OBSERVABILITY_BASE}/stats`, {
+      body: JSON.stringify({ element }),
+    });
+  };
+
+  const onClick: React.MouseEventHandler<HTMLDivElement> = (e) => {
+    let current = e.target as HTMLElement | null;
+    while (current) {
+      const element = current?.getAttribute('click-metric-element');
+      if (element) {
+        incrementCountMetric(element);
+        break;
+      }
+      current = current?.parentElement;
+    }
+  };
+
+  return <div onClick={onClick}>{props.children}</div>;
+};

--- a/dashboards-observability/public/components/common/metrics_listener.tsx
+++ b/dashboards-observability/public/components/common/metrics_listener.tsx
@@ -12,22 +12,19 @@ interface MetricsListenerProps {
 }
 
 export const MetricsListener: React.FC<MetricsListenerProps> = (props) => {
-  const incrementCountMetric = (element: string) => {
+  const incrementCountMetric = (element?: string | null) => {
+    if (!element) return;
     props.http.post(`${OBSERVABILITY_BASE}/stats`, {
       body: JSON.stringify({ element }),
     });
   };
 
   const onClick: React.MouseEventHandler<HTMLDivElement> = (e) => {
-    let current = e.target as HTMLElement | null;
-    while (current) {
-      const element = current?.getAttribute('click-metric-element');
-      if (element) {
-        incrementCountMetric(element);
-        break;
-      }
-      current = current?.parentElement;
-    }
+    incrementCountMetric(
+      (e.target as HTMLElement | null)
+        ?.closest('[data-click-metric-element]')
+        ?.getAttribute('data-click-metric-element')
+    );
   };
 
   return <div onClick={onClick}>{props.children}</div>;

--- a/dashboards-observability/public/components/trace_analytics/components/common/__tests__/__snapshots__/search_bar.test.tsx.snap
+++ b/dashboards-observability/public/components/trace_analytics/components/common/__tests__/__snapshots__/search_bar.test.tsx.snap
@@ -882,14 +882,14 @@ exports[`Search bar components renders search bar 1`] = `
           className="euiFlexItem euiFlexItem--flexGrowZero"
         >
           <EuiButton
-            click-metric-element="trace_analytics.refresh_button"
+            data-click-metric-element="trace_analytics.refresh_button"
             data-test-subj="superDatePickerApplyTimeButton"
             iconType="refresh"
             onClick={[MockFunction]}
           >
             <EuiButtonDisplay
               baseClassName="euiButton"
-              click-metric-element="trace_analytics.refresh_button"
+              data-click-metric-element="trace_analytics.refresh_button"
               data-test-subj="superDatePickerApplyTimeButton"
               disabled={false}
               element="button"
@@ -900,7 +900,7 @@ exports[`Search bar components renders search bar 1`] = `
             >
               <button
                 className="euiButton euiButton--primary"
-                click-metric-element="trace_analytics.refresh_button"
+                data-click-metric-element="trace_analytics.refresh_button"
                 data-test-subj="superDatePickerApplyTimeButton"
                 disabled={false}
                 onClick={[MockFunction]}

--- a/dashboards-observability/public/components/trace_analytics/components/common/__tests__/__snapshots__/search_bar.test.tsx.snap
+++ b/dashboards-observability/public/components/trace_analytics/components/common/__tests__/__snapshots__/search_bar.test.tsx.snap
@@ -882,12 +882,14 @@ exports[`Search bar components renders search bar 1`] = `
           className="euiFlexItem euiFlexItem--flexGrowZero"
         >
           <EuiButton
+            click-metric-element="trace_analytics.refresh_button"
             data-test-subj="superDatePickerApplyTimeButton"
             iconType="refresh"
             onClick={[MockFunction]}
           >
             <EuiButtonDisplay
               baseClassName="euiButton"
+              click-metric-element="trace_analytics.refresh_button"
               data-test-subj="superDatePickerApplyTimeButton"
               disabled={false}
               element="button"
@@ -898,6 +900,7 @@ exports[`Search bar components renders search bar 1`] = `
             >
               <button
                 className="euiButton euiButton--primary"
+                click-metric-element="trace_analytics.refresh_button"
                 data-test-subj="superDatePickerApplyTimeButton"
                 disabled={false}
                 onClick={[MockFunction]}

--- a/dashboards-observability/public/components/trace_analytics/components/common/search_bar.tsx
+++ b/dashboards-observability/public/components/trace_analytics/components/common/search_bar.tsx
@@ -81,7 +81,7 @@ export function SearchBar(props: SearchBarOwnProps) {
         <EuiFlexItem grow={false}>
           <EuiButton
             data-test-subj="superDatePickerApplyTimeButton"
-            click-metric-element="trace_analytics.refresh_button"
+            data-click-metric-element="trace_analytics.refresh_button"
             iconType="refresh"
             onClick={props.refresh}
           >

--- a/dashboards-observability/public/components/trace_analytics/components/common/search_bar.tsx
+++ b/dashboards-observability/public/components/trace_analytics/components/common/search_bar.tsx
@@ -81,6 +81,7 @@ export function SearchBar(props: SearchBarOwnProps) {
         <EuiFlexItem grow={false}>
           <EuiButton
             data-test-subj="superDatePickerApplyTimeButton"
+            click-metric-element="trace_analytics.refresh_button"
             iconType="refresh"
             onClick={props.refresh}
           >

--- a/dashboards-observability/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
+++ b/dashboards-observability/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
@@ -702,12 +702,14 @@ exports[`Dashboard component renders dashboard 1`] = `
               className="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <EuiButton
+                click-metric-element="trace_analytics.refresh_button"
                 data-test-subj="superDatePickerApplyTimeButton"
                 iconType="refresh"
                 onClick={[Function]}
               >
                 <EuiButtonDisplay
                   baseClassName="euiButton"
+                  click-metric-element="trace_analytics.refresh_button"
                   data-test-subj="superDatePickerApplyTimeButton"
                   disabled={false}
                   element="button"
@@ -718,6 +720,7 @@ exports[`Dashboard component renders dashboard 1`] = `
                 >
                   <button
                     className="euiButton euiButton--primary"
+                    click-metric-element="trace_analytics.refresh_button"
                     data-test-subj="superDatePickerApplyTimeButton"
                     disabled={false}
                     onClick={[Function]}
@@ -2749,12 +2752,14 @@ exports[`Dashboard component renders empty dashboard 1`] = `
               className="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <EuiButton
+                click-metric-element="trace_analytics.refresh_button"
                 data-test-subj="superDatePickerApplyTimeButton"
                 iconType="refresh"
                 onClick={[Function]}
               >
                 <EuiButtonDisplay
                   baseClassName="euiButton"
+                  click-metric-element="trace_analytics.refresh_button"
                   data-test-subj="superDatePickerApplyTimeButton"
                   disabled={false}
                   element="button"
@@ -2765,6 +2770,7 @@ exports[`Dashboard component renders empty dashboard 1`] = `
                 >
                   <button
                     className="euiButton euiButton--primary"
+                    click-metric-element="trace_analytics.refresh_button"
                     data-test-subj="superDatePickerApplyTimeButton"
                     disabled={false}
                     onClick={[Function]}

--- a/dashboards-observability/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
+++ b/dashboards-observability/public/components/trace_analytics/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
@@ -702,14 +702,14 @@ exports[`Dashboard component renders dashboard 1`] = `
               className="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <EuiButton
-                click-metric-element="trace_analytics.refresh_button"
+                data-click-metric-element="trace_analytics.refresh_button"
                 data-test-subj="superDatePickerApplyTimeButton"
                 iconType="refresh"
                 onClick={[Function]}
               >
                 <EuiButtonDisplay
                   baseClassName="euiButton"
-                  click-metric-element="trace_analytics.refresh_button"
+                  data-click-metric-element="trace_analytics.refresh_button"
                   data-test-subj="superDatePickerApplyTimeButton"
                   disabled={false}
                   element="button"
@@ -720,7 +720,7 @@ exports[`Dashboard component renders dashboard 1`] = `
                 >
                   <button
                     className="euiButton euiButton--primary"
-                    click-metric-element="trace_analytics.refresh_button"
+                    data-click-metric-element="trace_analytics.refresh_button"
                     data-test-subj="superDatePickerApplyTimeButton"
                     disabled={false}
                     onClick={[Function]}
@@ -2752,14 +2752,14 @@ exports[`Dashboard component renders empty dashboard 1`] = `
               className="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <EuiButton
-                click-metric-element="trace_analytics.refresh_button"
+                data-click-metric-element="trace_analytics.refresh_button"
                 data-test-subj="superDatePickerApplyTimeButton"
                 iconType="refresh"
                 onClick={[Function]}
               >
                 <EuiButtonDisplay
                   baseClassName="euiButton"
-                  click-metric-element="trace_analytics.refresh_button"
+                  data-click-metric-element="trace_analytics.refresh_button"
                   data-test-subj="superDatePickerApplyTimeButton"
                   disabled={false}
                   element="button"
@@ -2770,7 +2770,7 @@ exports[`Dashboard component renders empty dashboard 1`] = `
                 >
                   <button
                     className="euiButton euiButton--primary"
-                    click-metric-element="trace_analytics.refresh_button"
+                    data-click-metric-element="trace_analytics.refresh_button"
                     data-test-subj="superDatePickerApplyTimeButton"
                     disabled={false}
                     onClick={[Function]}

--- a/dashboards-observability/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
+++ b/dashboards-observability/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
@@ -692,14 +692,14 @@ exports[`Services component renders empty services page 1`] = `
               className="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <EuiButton
-                click-metric-element="trace_analytics.refresh_button"
+                data-click-metric-element="trace_analytics.refresh_button"
                 data-test-subj="superDatePickerApplyTimeButton"
                 iconType="refresh"
                 onClick={[Function]}
               >
                 <EuiButtonDisplay
                   baseClassName="euiButton"
-                  click-metric-element="trace_analytics.refresh_button"
+                  data-click-metric-element="trace_analytics.refresh_button"
                   data-test-subj="superDatePickerApplyTimeButton"
                   disabled={false}
                   element="button"
@@ -710,7 +710,7 @@ exports[`Services component renders empty services page 1`] = `
                 >
                   <button
                     className="euiButton euiButton--primary"
-                    click-metric-element="trace_analytics.refresh_button"
+                    data-click-metric-element="trace_analytics.refresh_button"
                     data-test-subj="superDatePickerApplyTimeButton"
                     disabled={false}
                     onClick={[Function]}
@@ -2441,14 +2441,14 @@ exports[`Services component renders services page 1`] = `
               className="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <EuiButton
-                click-metric-element="trace_analytics.refresh_button"
+                data-click-metric-element="trace_analytics.refresh_button"
                 data-test-subj="superDatePickerApplyTimeButton"
                 iconType="refresh"
                 onClick={[Function]}
               >
                 <EuiButtonDisplay
                   baseClassName="euiButton"
-                  click-metric-element="trace_analytics.refresh_button"
+                  data-click-metric-element="trace_analytics.refresh_button"
                   data-test-subj="superDatePickerApplyTimeButton"
                   disabled={false}
                   element="button"
@@ -2459,7 +2459,7 @@ exports[`Services component renders services page 1`] = `
                 >
                   <button
                     className="euiButton euiButton--primary"
-                    click-metric-element="trace_analytics.refresh_button"
+                    data-click-metric-element="trace_analytics.refresh_button"
                     data-test-subj="superDatePickerApplyTimeButton"
                     disabled={false}
                     onClick={[Function]}

--- a/dashboards-observability/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
+++ b/dashboards-observability/public/components/trace_analytics/components/services/__tests__/__snapshots__/services.test.tsx.snap
@@ -692,12 +692,14 @@ exports[`Services component renders empty services page 1`] = `
               className="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <EuiButton
+                click-metric-element="trace_analytics.refresh_button"
                 data-test-subj="superDatePickerApplyTimeButton"
                 iconType="refresh"
                 onClick={[Function]}
               >
                 <EuiButtonDisplay
                   baseClassName="euiButton"
+                  click-metric-element="trace_analytics.refresh_button"
                   data-test-subj="superDatePickerApplyTimeButton"
                   disabled={false}
                   element="button"
@@ -708,6 +710,7 @@ exports[`Services component renders empty services page 1`] = `
                 >
                   <button
                     className="euiButton euiButton--primary"
+                    click-metric-element="trace_analytics.refresh_button"
                     data-test-subj="superDatePickerApplyTimeButton"
                     disabled={false}
                     onClick={[Function]}
@@ -2438,12 +2441,14 @@ exports[`Services component renders services page 1`] = `
               className="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <EuiButton
+                click-metric-element="trace_analytics.refresh_button"
                 data-test-subj="superDatePickerApplyTimeButton"
                 iconType="refresh"
                 onClick={[Function]}
               >
                 <EuiButtonDisplay
                   baseClassName="euiButton"
+                  click-metric-element="trace_analytics.refresh_button"
                   data-test-subj="superDatePickerApplyTimeButton"
                   disabled={false}
                   element="button"
@@ -2454,6 +2459,7 @@ exports[`Services component renders services page 1`] = `
                 >
                   <button
                     className="euiButton euiButton--primary"
+                    click-metric-element="trace_analytics.refresh_button"
                     data-test-subj="superDatePickerApplyTimeButton"
                     disabled={false}
                     onClick={[Function]}

--- a/dashboards-observability/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
+++ b/dashboards-observability/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
@@ -690,14 +690,14 @@ exports[`Traces component renders empty traces page 1`] = `
               className="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <EuiButton
-                click-metric-element="trace_analytics.refresh_button"
+                data-click-metric-element="trace_analytics.refresh_button"
                 data-test-subj="superDatePickerApplyTimeButton"
                 iconType="refresh"
                 onClick={[Function]}
               >
                 <EuiButtonDisplay
                   baseClassName="euiButton"
-                  click-metric-element="trace_analytics.refresh_button"
+                  data-click-metric-element="trace_analytics.refresh_button"
                   data-test-subj="superDatePickerApplyTimeButton"
                   disabled={false}
                   element="button"
@@ -708,7 +708,7 @@ exports[`Traces component renders empty traces page 1`] = `
                 >
                   <button
                     className="euiButton euiButton--primary"
-                    click-metric-element="trace_analytics.refresh_button"
+                    data-click-metric-element="trace_analytics.refresh_button"
                     data-test-subj="superDatePickerApplyTimeButton"
                     disabled={false}
                     onClick={[Function]}
@@ -1905,14 +1905,14 @@ exports[`Traces component renders traces page 1`] = `
               className="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <EuiButton
-                click-metric-element="trace_analytics.refresh_button"
+                data-click-metric-element="trace_analytics.refresh_button"
                 data-test-subj="superDatePickerApplyTimeButton"
                 iconType="refresh"
                 onClick={[Function]}
               >
                 <EuiButtonDisplay
                   baseClassName="euiButton"
-                  click-metric-element="trace_analytics.refresh_button"
+                  data-click-metric-element="trace_analytics.refresh_button"
                   data-test-subj="superDatePickerApplyTimeButton"
                   disabled={false}
                   element="button"
@@ -1923,7 +1923,7 @@ exports[`Traces component renders traces page 1`] = `
                 >
                   <button
                     className="euiButton euiButton--primary"
-                    click-metric-element="trace_analytics.refresh_button"
+                    data-click-metric-element="trace_analytics.refresh_button"
                     data-test-subj="superDatePickerApplyTimeButton"
                     disabled={false}
                     onClick={[Function]}

--- a/dashboards-observability/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
+++ b/dashboards-observability/public/components/trace_analytics/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
@@ -690,12 +690,14 @@ exports[`Traces component renders empty traces page 1`] = `
               className="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <EuiButton
+                click-metric-element="trace_analytics.refresh_button"
                 data-test-subj="superDatePickerApplyTimeButton"
                 iconType="refresh"
                 onClick={[Function]}
               >
                 <EuiButtonDisplay
                   baseClassName="euiButton"
+                  click-metric-element="trace_analytics.refresh_button"
                   data-test-subj="superDatePickerApplyTimeButton"
                   disabled={false}
                   element="button"
@@ -706,6 +708,7 @@ exports[`Traces component renders empty traces page 1`] = `
                 >
                   <button
                     className="euiButton euiButton--primary"
+                    click-metric-element="trace_analytics.refresh_button"
                     data-test-subj="superDatePickerApplyTimeButton"
                     disabled={false}
                     onClick={[Function]}
@@ -1902,12 +1905,14 @@ exports[`Traces component renders traces page 1`] = `
               className="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <EuiButton
+                click-metric-element="trace_analytics.refresh_button"
                 data-test-subj="superDatePickerApplyTimeButton"
                 iconType="refresh"
                 onClick={[Function]}
               >
                 <EuiButtonDisplay
                   baseClassName="euiButton"
+                  click-metric-element="trace_analytics.refresh_button"
                   data-test-subj="superDatePickerApplyTimeButton"
                   disabled={false}
                   element="button"
@@ -1918,6 +1923,7 @@ exports[`Traces component renders traces page 1`] = `
                 >
                   <button
                     className="euiButton euiButton--primary"
+                    click-metric-element="trace_analytics.refresh_button"
                     data-test-subj="superDatePickerApplyTimeButton"
                     disabled={false}
                     onClick={[Function]}

--- a/dashboards-observability/server/common/metrics/constants.ts
+++ b/dashboards-observability/server/common/metrics/constants.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ComponentType, CounterNameType, CounterType } from './types';
+import { ComponentType, CounterType } from './types';
 
 export const WINDOW = 3600;
 export const INTERVAL = 60;
@@ -26,7 +26,6 @@ export const GLOBAL_BASIC_COUNTER: CounterType = (() => {
     counter[component] = {} as CounterType[ComponentType];
     REQUESTS.forEach((request) => {
       counter[component][request] = {
-        count: 0,
         total: 0,
       };
     });

--- a/dashboards-observability/server/common/metrics/constants.ts
+++ b/dashboards-observability/server/common/metrics/constants.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ComponentType, CounterNameType, CounterType } from './types';
+
+export const WINDOW = 3600;
+export const INTERVAL = 60;
+export const CAPACITY = (WINDOW / INTERVAL) * 2;
+export const MILLIS_MULTIPLIER = 1000;
+
+export const COMPONENTS = [
+  'application_analytics',
+  'operational_panels',
+  'event_analytics',
+  'notebooks',
+  'trace_analytics',
+  'metrics_analytics',
+] as const;
+export const REQUESTS = ['create', 'get', 'update', 'delete'] as const;
+
+export const GLOBAL_BASIC_COUNTER: CounterType = (() => {
+  const counter = {} as CounterType;
+  COMPONENTS.forEach((component) => {
+    counter[component] = {} as CounterType[ComponentType];
+    REQUESTS.forEach((request) => {
+      counter[component][request] = {
+        count: 0,
+        total: 0,
+      };
+    });
+  });
+  return counter;
+})();
+
+export const DEFAULT_ROLLING_COUNTER: CounterType = (() => {
+  const counter = {} as CounterType;
+  COMPONENTS.forEach((component) => {
+    counter[component] = {} as CounterType[ComponentType];
+    REQUESTS.forEach((request) => {
+      counter[component][request] = {
+        count: 0,
+        system_error: 0,
+        user_error: 0,
+        total: 0,
+      };
+    });
+  });
+  return counter;
+})();

--- a/dashboards-observability/server/common/metrics/constants.ts
+++ b/dashboards-observability/server/common/metrics/constants.ts
@@ -42,7 +42,6 @@ export const DEFAULT_ROLLING_COUNTER: CounterType = (() => {
         count: 0,
         system_error: 0,
         user_error: 0,
-        total: 0,
       };
     });
   });

--- a/dashboards-observability/server/common/metrics/metrics_helper.ts
+++ b/dashboards-observability/server/common/metrics/metrics_helper.ts
@@ -6,7 +6,7 @@
 import _ from 'lodash';
 import {
   CAPACITY,
-    COMPONENTS,
+  COMPONENTS,
   DEFAULT_ROLLING_COUNTER,
   GLOBAL_BASIC_COUNTER,
   INTERVAL,
@@ -15,13 +15,48 @@ import {
 } from './constants';
 import { ComponentType, CounterNameType, CounterType, RequestType } from './types';
 
-export const time2CountWin: Map<number, CounterType> = new Map();
+const time2CountWin: Map<number, CounterType> = new Map();
 
-export const addRequestToMetric = (
+export function addClickToMetric(element: string, counter: CounterNameType = 'count') {
+  // remove outdated key-value pairs
+  trim();
+
+  const timeKey = getKey(Date.now());
+  const rollingCounter = time2CountWin.get(timeKey) || _.cloneDeep(DEFAULT_ROLLING_COUNTER);
+  const path = `${element}.${counter}`;
+
+  _.set(rollingCounter, path, (_.get(rollingCounter, path, 0) as number) + 1);
+  if (counter === 'count') {
+    _.set(
+      GLOBAL_BASIC_COUNTER,
+      `${element}.total`,
+      (_.get(GLOBAL_BASIC_COUNTER, `${element}.total`, 0) as number) + 1
+    );
+  }
+
+  time2CountWin.set(timeKey, rollingCounter);
+}
+
+export function addRequestToMetric(
+  component: ComponentType,
+  request: RequestType,
+  error: { statusCode: number }
+): void;
+export function addRequestToMetric(
   component: ComponentType,
   request: RequestType,
   counter: CounterNameType
-) => {
+): void;
+export function addRequestToMetric(
+  component: ComponentType,
+  request: RequestType,
+  counterNameOrError: CounterNameType | { statusCode: number }
+) {
+  const counter =
+    typeof counterNameOrError === 'object'
+      ? checkErrorType(counterNameOrError)
+      : counterNameOrError;
+
   // remove outdated key-value pairs
   trim();
 
@@ -34,13 +69,21 @@ export const addRequestToMetric = (
   }
 
   time2CountWin.set(timeKey, rollingCounter);
-};
+}
 
 export const getMetrics = () => {
-  const preTimeKey = getPreKey(Date.now());
+  // const preTimeKey = getPreKey(Date.now());
+  const preTimeKey = getKey(Date.now());
   const rollingCounters = time2CountWin.get(preTimeKey);
-  const metrics = buildMetrics(rollingCounters);
-  return metrics;
+  return buildMetrics(rollingCounters);
+};
+
+const checkErrorType = (error: { statusCode: number }) => {
+  if (error.statusCode && Math.floor(error.statusCode / 100) === 4) {
+    return 'user_error';
+  } else {
+    return 'system_error';
+  }
 };
 
 const trim = () => {
@@ -95,4 +138,3 @@ const buildMetrics = (rollingCounters?: CounterType) => {
 
   return { ...basicMetrics, ...overallActionMetrics };
 };
-

--- a/dashboards-observability/server/common/metrics/metrics_helper.ts
+++ b/dashboards-observability/server/common/metrics/metrics_helper.ts
@@ -72,8 +72,7 @@ export function addRequestToMetric(
 }
 
 export const getMetrics = () => {
-  // const preTimeKey = getPreKey(Date.now());
-  const preTimeKey = getKey(Date.now());
+  const preTimeKey = getPreKey(Date.now());
   const rollingCounters = time2CountWin.get(preTimeKey);
   return buildMetrics(rollingCounters);
 };

--- a/dashboards-observability/server/common/metrics/metrics_helper.ts
+++ b/dashboards-observability/server/common/metrics/metrics_helper.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import _ from 'lodash';
+import {
+  CAPACITY,
+    COMPONENTS,
+  DEFAULT_ROLLING_COUNTER,
+  GLOBAL_BASIC_COUNTER,
+  INTERVAL,
+  MILLIS_MULTIPLIER,
+  WINDOW,
+} from './constants';
+import { ComponentType, CounterNameType, CounterType, RequestType } from './types';
+
+export const time2CountWin: Map<number, CounterType> = new Map();
+
+export const addRequestToMetric = (
+  component: ComponentType,
+  request: RequestType,
+  counter: CounterNameType
+) => {
+  // remove outdated key-value pairs
+  trim();
+
+  const timeKey = getKey(Date.now());
+  const rollingCounter = time2CountWin.get(timeKey) || _.cloneDeep(DEFAULT_ROLLING_COUNTER);
+
+  rollingCounter[component][request][counter]!++;
+  if (counter === 'count') {
+    GLOBAL_BASIC_COUNTER[component][request]['total']!++;
+  }
+
+  time2CountWin.set(timeKey, rollingCounter);
+};
+
+export const getMetrics = () => {
+  const preTimeKey = getPreKey(Date.now());
+  const rollingCounters = time2CountWin.get(preTimeKey);
+  const metrics = buildMetrics(rollingCounters);
+  return metrics;
+};
+
+const trim = () => {
+  if (time2CountWin.size > CAPACITY) {
+    const currentKey = getKey(Date.now() - WINDOW * MILLIS_MULTIPLIER);
+    time2CountWin.forEach((_value, key, map) => {
+      if (key < currentKey) {
+        map.delete(key);
+      }
+    });
+  }
+};
+
+const getKey = (milliseconds: number) => {
+  return Math.floor(milliseconds / MILLIS_MULTIPLIER / INTERVAL);
+};
+
+const getPreKey = (milliseconds: number) => {
+  return getKey(milliseconds) - 1;
+};
+
+const isComponent = (arg: string): arg is ComponentType => {
+  return COMPONENTS.includes(arg as ComponentType);
+};
+
+const buildMetrics = (rollingCounters?: CounterType) => {
+  if (!rollingCounters) {
+    rollingCounters = DEFAULT_ROLLING_COUNTER;
+  }
+  const basicMetrics = _.merge(rollingCounters, GLOBAL_BASIC_COUNTER);
+  const overallActionMetrics = {
+    request_total: 0,
+    request_count: 0,
+    success_count: 0,
+    failed_request_count_system_error: 0,
+    failed_request_count_user_error: 0,
+  };
+  Object.keys(basicMetrics).forEach((key) => {
+    if (isComponent(key)) {
+      for (const counter of Object.values(basicMetrics[key])) {
+        overallActionMetrics.request_count += counter?.count || 0;
+        overallActionMetrics.request_total += counter?.total || 0;
+        overallActionMetrics.failed_request_count_system_error += counter?.system_error || 0;
+        overallActionMetrics.failed_request_count_user_error += counter?.user_error || 0;
+      }
+    }
+  });
+  overallActionMetrics.success_count =
+    overallActionMetrics.request_count -
+    (overallActionMetrics.failed_request_count_system_error +
+      overallActionMetrics.failed_request_count_user_error);
+
+  return { ...basicMetrics, ...overallActionMetrics };
+};
+

--- a/dashboards-observability/server/common/metrics/metrics_helper.ts
+++ b/dashboards-observability/server/common/metrics/metrics_helper.ts
@@ -23,14 +23,15 @@ export function addClickToMetric(element: string, counter: CounterNameType = 'co
 
   const timeKey = getKey(Date.now());
   const rollingCounter = time2CountWin.get(timeKey) || _.cloneDeep(DEFAULT_ROLLING_COUNTER);
-  const path = `${element}.${counter}`;
+  const key = `click.${element}.${counter}`;
 
-  _.set(rollingCounter, path, (_.get(rollingCounter, path, 0) as number) + 1);
+  _.set(rollingCounter, key, (_.get(rollingCounter, key, 0) as number) + 1);
   if (counter === 'count') {
+    const basicCounterKey = `click.${element}.total`;
     _.set(
       GLOBAL_BASIC_COUNTER,
-      `${element}.total`,
-      (_.get(GLOBAL_BASIC_COUNTER, `${element}.total`, 0) as number) + 1
+      basicCounterKey,
+      (_.get(GLOBAL_BASIC_COUNTER, basicCounterKey, 0) as number) + 1
     );
   }
 

--- a/dashboards-observability/server/common/metrics/types.ts
+++ b/dashboards-observability/server/common/metrics/types.ts
@@ -11,7 +11,7 @@ export type CounterNameType = 'count' | 'system_error' | 'user_error' | 'total';
 
 // counter to track user click actions
 type ClickCounterType = {
-  [action: string]: {
+  [element: string]: {
     [counter in CounterNameType]?: number;
   };
 };

--- a/dashboards-observability/server/common/metrics/types.ts
+++ b/dashboards-observability/server/common/metrics/types.ts
@@ -16,7 +16,7 @@ type ClickCounterType = {
   };
 };
 
-// counter to tract requests to OpenSearch
+// counter to track requests to OpenSearch
 type RequestCounterType = {
   [component in ComponentType]: {
     [request in RequestType]: {

--- a/dashboards-observability/server/common/metrics/types.ts
+++ b/dashboards-observability/server/common/metrics/types.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { COMPONENTS, REQUESTS } from './constants';
+
+export type ComponentType = typeof COMPONENTS[number];
+export type RequestType = typeof REQUESTS[number];
+export type CounterNameType = 'count' | 'system_error' | 'user_error' | 'total';
+
+// counter to track user click actions
+type ClickCounterType = {
+  [action: string]: {
+    [counter in CounterNameType]?: number;
+  };
+};
+
+// counter to tract requests to OpenSearch
+type RequestCounterType = {
+  [component in ComponentType]: {
+    [request in RequestType]: {
+      [counter in CounterNameType]?: number;
+    };
+  };
+};
+
+export type CounterType = ClickCounterType & RequestCounterType;

--- a/dashboards-observability/server/routes/index.ts
+++ b/dashboards-observability/server/routes/index.ts
@@ -19,6 +19,7 @@ import QueryService from '../services/queryService';
 import { registerSqlRoute } from './notebooks/sqlRouter';
 import { registerEventAnalyticsRouter } from './event_analytics/event_analytics_router';
 import { registerAppAnalyticsRouter } from './application_analytics/app_analytics_router';
+import { registerMetricsRoute } from './metrics/metrics_rounter';
 
 
 export function setupRoutes({ router, client }: { router: IRouter; client: ILegacyClusterClient }) {
@@ -38,4 +39,6 @@ export function setupRoutes({ router, client }: { router: IRouter; client: ILega
   registerVizRoute(router);
   const queryService = new QueryService(client);
   registerSqlRoute(router, queryService);
+
+  registerMetricsRoute(router);
 };

--- a/dashboards-observability/server/routes/metrics/metrics_rounter.ts
+++ b/dashboards-observability/server/routes/metrics/metrics_rounter.ts
@@ -4,9 +4,10 @@
  */
 
 import { ResponseError } from '@opensearch-project/opensearch/lib/errors';
+import { schema } from '@osd/config-schema';
 import { IOpenSearchDashboardsResponse, IRouter } from '../../../../../src/core/server';
 import { OBSERVABILITY_BASE } from '../../../common/constants/shared';
-import { getMetrics } from '../../common/metrics/metrics_helper';
+import { addClickToMetric, getMetrics } from '../../common/metrics/metrics_helper';
 
 export function registerMetricsRoute(router: IRouter) {
   router.get(
@@ -24,6 +25,34 @@ export function registerMetricsRoute(router: IRouter) {
         return response.ok({
           body: metrics,
         });
+      } catch (error) {
+        console.error(error);
+        return response.custom({
+          statusCode: error.statusCode || 500,
+          body: error.message,
+        });
+      }
+    }
+  );
+
+  router.post(
+    {
+      path: `${OBSERVABILITY_BASE}/stats`,
+      validate: {
+        body: schema.object({
+          element: schema.string()
+        }),
+      },
+    },
+    async (
+      context,
+      request,
+      response
+    ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
+      try {
+        const { element } = request.body;
+        addClickToMetric(element);
+        return response.ok();
       } catch (error) {
         console.error(error);
         return response.custom({

--- a/dashboards-observability/server/routes/metrics/metrics_rounter.ts
+++ b/dashboards-observability/server/routes/metrics/metrics_rounter.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ResponseError } from '@opensearch-project/opensearch/lib/errors';
+import { IOpenSearchDashboardsResponse, IRouter } from '../../../../../src/core/server';
+import { OBSERVABILITY_BASE } from '../../../common/constants/shared';
+import { getMetrics } from '../../common/metrics/metrics_helper';
+
+export function registerMetricsRoute(router: IRouter) {
+  router.get(
+    {
+      path: `${OBSERVABILITY_BASE}/stats`,
+      validate: false,
+    },
+    async (
+      context,
+      request,
+      response
+    ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
+      try {
+        const metrics = getMetrics();
+        return response.ok({
+          body: metrics,
+        });
+      } catch (error) {
+        console.error(error);
+        return response.custom({
+          statusCode: error.statusCode || 500,
+          body: error.message,
+        });
+      }
+    }
+  );
+}

--- a/dashboards-observability/server/routes/trace_analytics_dsl_router.ts
+++ b/dashboards-observability/server/routes/trace_analytics_dsl_router.ts
@@ -3,10 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { RequestParams } from '@elastic/elasticsearch';
+import { RequestParams } from '@opensearch-project/opensearch';
 import { schema } from '@osd/config-schema';
 import { IRouter } from '../../../../src/core/server';
-import { TRACE_ANALYTICS_DSL_ROUTE, TRACE_ANALYTICS_INDICES_ROUTE, DATA_PREPPER_INDEX_NAME, DATA_PREPPER_SERVICE_INDEX_NAME } from '../../common/constants/trace_analytics';
+import {
+  DATA_PREPPER_INDEX_NAME,
+  DATA_PREPPER_SERVICE_INDEX_NAME,
+  TRACE_ANALYTICS_DSL_ROUTE,
+  TRACE_ANALYTICS_INDICES_ROUTE,
+} from '../../common/constants/trace_analytics';
+import { addRequestToMetric } from '../common/metrics/metrics_helper';
 
 export function registerTraceAnalyticsDslRouter(router: IRouter) {
   router.post(
@@ -70,6 +76,7 @@ export function registerTraceAnalyticsDslRouter(router: IRouter) {
       },
     },
     async (context, request, response) => {
+      addRequestToMetric('trace_analytics', 'get', 'count');
       const { index, size, ...rest } = request.body;
       const params: RequestParams.Search = {
         index: index || DATA_PREPPER_INDEX_NAME,
@@ -85,6 +92,7 @@ export function registerTraceAnalyticsDslRouter(router: IRouter) {
           body: resp,
         });
       } catch (error) {
+        addRequestToMetric('trace_analytics', 'get', error);
         if (error.statusCode !== 404) console.error(error);
         return response.custom({
           statusCode: error.statusCode || 500,

--- a/opensearch-observability/build.gradle
+++ b/opensearch-observability/build.gradle
@@ -182,8 +182,14 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9"
     implementation "${group}:common-utils:${common_utils_version}"
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
-    implementation "org.json:json:20180813"
-    implementation group: 'com.github.wnameless', name: 'json-flattener', version: '0.1.0'
+    implementation 'org.json:json:20220924'
+    implementation group: 'com.github.wnameless.json', name: 'json-flattener', version: '0.15.1'
+    // json-base, jackson-databind, jackson-annotations are only used by json-flattener
+    // and are included in its pom.xml, but json-flattener returns ClassNotFoundException
+    // for them if not declared explicitly
+    implementation group: 'com.github.wnameless.json', name: 'json-base', version: '2.2.1'
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.13.4"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:2.13.4"
     compileOnly "${group}:opensearch-job-scheduler-spi:${job_scheduler_version}"
     testImplementation(
             'org.assertj:assertj-core:3.16.1',

--- a/opensearch-observability/build.gradle
+++ b/opensearch-observability/build.gradle
@@ -194,6 +194,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
     testImplementation "org.mockito:mockito-core:4.3.1"
+    testImplementation "org.mockito:mockito-junit-jupiter:4.3.1"
     testImplementation "com.google.code.gson:gson:2.8.9"
 
     ktlint "com.pinterest:ktlint:0.45.0"

--- a/opensearch-observability/build.gradle
+++ b/opensearch-observability/build.gradle
@@ -182,6 +182,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9"
     implementation "${group}:common-utils:${common_utils_version}"
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
+    implementation "org.json:json:20180813"
+    implementation group: 'com.github.wnameless', name: 'json-flattener', version: '0.1.0'
     compileOnly "${group}:opensearch-job-scheduler-spi:${job_scheduler_version}"
     testImplementation(
             'org.assertj:assertj-core:3.16.1',

--- a/opensearch-observability/build.gradle
+++ b/opensearch-observability/build.gradle
@@ -23,6 +23,7 @@ buildscript {
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
         kotlin_version = System.getProperty("kotlin.version", "1.6.0")
         job_scheduler_version = System.getProperty("job_scheduler.version", opensearch_build)
+        jackson_version = "2.14.1"
     }
 
     repositories {
@@ -139,7 +140,7 @@ configurations.all {
     resolutionStrategy {
         force "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
         force "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
-        force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.4"
+        force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jackson_version}"
         force "org.mockito:mockito-core:4.6.1"
         force "org.yaml:snakeyaml:1.32"
     }
@@ -184,12 +185,11 @@ dependencies {
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     implementation 'org.json:json:20220924'
     implementation group: 'com.github.wnameless.json', name: 'json-flattener', version: '0.15.1'
-    // json-base, jackson-databind, jackson-annotations are only used by json-flattener
-    // and are included in its pom.xml, but json-flattener returns ClassNotFoundException
-    // for them if not declared explicitly
+    // json-base, jackson-databind, jackson-annotations are only used by json-flattener.
+    // see https://github.com/opensearch-project/OpenSearch/issues/5395.
     implementation group: 'com.github.wnameless.json', name: 'json-base', version: '2.2.1'
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.13.4"
-    implementation "com.fasterxml.jackson.core:jackson-annotations:2.13.4"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:${jackson_version}"
     compileOnly "${group}:opensearch-job-scheduler-spi:${job_scheduler_version}"
     testImplementation(
             'org.assertj:assertj-core:3.16.1',

--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/ObservabilityPlugin.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/ObservabilityPlugin.kt
@@ -28,6 +28,7 @@ import org.opensearch.observability.action.GetObservabilityObjectAction
 import org.opensearch.observability.action.UpdateObservabilityObjectAction
 import org.opensearch.observability.index.ObservabilityIndex
 import org.opensearch.observability.resthandler.ObservabilityRestHandler
+import org.opensearch.observability.resthandler.ObservabilityStatsRestHandler
 import org.opensearch.observability.resthandler.SchedulerRestHandler
 import org.opensearch.observability.scheduler.ObservabilityJobParser
 import org.opensearch.observability.scheduler.ObservabilityJobRunner
@@ -97,6 +98,7 @@ class ObservabilityPlugin : Plugin(), ActionPlugin, JobSchedulerExtension {
     ): List<RestHandler> {
         return listOf(
             ObservabilityRestHandler(),
+            ObservabilityStatsRestHandler(),
             SchedulerRestHandler() // TODO: tmp rest handler only for POC purpose
         )
     }

--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/action/ObservabilityActions.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/action/ObservabilityActions.kt
@@ -9,6 +9,7 @@ import org.opensearch.OpenSearchStatusException
 import org.opensearch.commons.authuser.User
 import org.opensearch.observability.ObservabilityPlugin.Companion.LOG_PREFIX
 import org.opensearch.observability.index.ObservabilityIndex
+import org.opensearch.observability.metrics.Metrics
 import org.opensearch.observability.model.ObservabilityObjectDoc
 import org.opensearch.observability.model.ObservabilityObjectSearchResult
 import org.opensearch.observability.security.UserAccessManager
@@ -64,6 +65,7 @@ internal object ObservabilityActions {
             )
         val currentDoc = observabilityObject.observabilityObjectDoc
         if (!UserAccessManager.doesUserHasAccess(user, currentDoc.tenant, currentDoc.access)) {
+            Metrics.OBSERVABILITY_PERMISSION_USER_ERROR.counter.increment()
             throw OpenSearchStatusException(
                 "Permission denied for ObservabilityObject ${request.objectId}",
                 RestStatus.FORBIDDEN
@@ -118,6 +120,7 @@ internal object ObservabilityActions {
             }
         val currentDoc = observabilityObjectDocInfo.observabilityObjectDoc
         if (!UserAccessManager.doesUserHasAccess(user, currentDoc.tenant, currentDoc.access)) {
+            Metrics.OBSERVABILITY_PERMISSION_USER_ERROR.counter.increment()
             throw OpenSearchStatusException("Permission denied for ObservabilityObject $objectId", RestStatus.FORBIDDEN)
         }
         val docInfo = ObservabilityObjectDoc(
@@ -155,6 +158,7 @@ internal object ObservabilityActions {
         objectDocs.forEach {
             val currentDoc = it.observabilityObjectDoc
             if (!UserAccessManager.doesUserHasAccess(user, currentDoc.tenant, currentDoc.access)) {
+                Metrics.OBSERVABILITY_PERMISSION_USER_ERROR.counter.increment()
                 throw OpenSearchStatusException(
                     "Permission denied for ObservabilityObject ${it.id}",
                     RestStatus.FORBIDDEN
@@ -230,6 +234,7 @@ internal object ObservabilityActions {
 
         val currentDoc = observabilityObjectDocInfo.observabilityObjectDoc
         if (!UserAccessManager.doesUserHasAccess(user, currentDoc.tenant, currentDoc.access)) {
+            Metrics.OBSERVABILITY_PERMISSION_USER_ERROR.counter.increment()
             throw OpenSearchStatusException(
                 "Permission denied for ObservabilityObject $objectId",
                 RestStatus.FORBIDDEN
@@ -265,6 +270,7 @@ internal object ObservabilityActions {
         configDocs.forEach {
             val currentDoc = it.observabilityObjectDoc
             if (!UserAccessManager.doesUserHasAccess(user, currentDoc.tenant, currentDoc.access)) {
+                Metrics.OBSERVABILITY_PERMISSION_USER_ERROR.counter.increment()
                 throw OpenSearchStatusException(
                     "Permission denied for ObservabilityObject ${it.id}",
                     RestStatus.FORBIDDEN

--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/action/PluginBaseAction.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/action/PluginBaseAction.kt
@@ -23,6 +23,7 @@ import org.opensearch.index.IndexNotFoundException
 import org.opensearch.index.engine.VersionConflictEngineException
 import org.opensearch.indices.InvalidIndexNameException
 import org.opensearch.observability.ObservabilityPlugin.Companion.LOG_PREFIX
+import org.opensearch.observability.metrics.Metrics
 import org.opensearch.observability.util.logger
 import org.opensearch.rest.RestStatus
 import org.opensearch.tasks.Task
@@ -56,9 +57,11 @@ abstract class PluginBaseAction<Request : ActionRequest, Response : ActionRespon
             try {
                 listener.onResponse(executeRequest(request, user))
             } catch (exception: OpenSearchStatusException) {
+                Metrics.OBSERVABILITY_EXCEPTIONS_OPENSEARCH_STATUS_EXCEPTION.counter.increment()
                 log.warn("$LOG_PREFIX:OpenSearchStatusException: message:${exception.message}")
                 listener.onFailure(exception)
             } catch (exception: OpenSearchSecurityException) {
+                Metrics.OBSERVABILITY_EXCEPTIONS_OPENSEARCH_SECURITY_EXCEPTION.counter.increment()
                 log.warn("$LOG_PREFIX:OpenSearchSecurityException:", exception)
                 listener.onFailure(
                     OpenSearchStatusException(
@@ -67,24 +70,31 @@ abstract class PluginBaseAction<Request : ActionRequest, Response : ActionRespon
                     )
                 )
             } catch (exception: VersionConflictEngineException) {
+                Metrics.OBSERVABILITY_EXCEPTIONS_VERSION_CONFLICT_ENGINE_EXCEPTION.counter.increment()
                 log.warn("$LOG_PREFIX:VersionConflictEngineException:", exception)
                 listener.onFailure(OpenSearchStatusException(exception.message, RestStatus.CONFLICT))
             } catch (exception: IndexNotFoundException) {
+                Metrics.OBSERVABILITY_EXCEPTIONS_INDEX_NOT_FOUND_EXCEPTION.counter.increment()
                 log.warn("$LOG_PREFIX:IndexNotFoundException:", exception)
                 listener.onFailure(OpenSearchStatusException(exception.message, RestStatus.NOT_FOUND))
             } catch (exception: InvalidIndexNameException) {
+                Metrics.OBSERVABILITY_EXCEPTIONS_INVALID_INDEX_NAME_EXCEPTION.counter.increment()
                 log.warn("$LOG_PREFIX:InvalidIndexNameException:", exception)
                 listener.onFailure(OpenSearchStatusException(exception.message, RestStatus.BAD_REQUEST))
             } catch (exception: IllegalArgumentException) {
+                Metrics.OBSERVABILITY_EXCEPTIONS_ILLEGAL_ARGUMENT_EXCEPTION.counter.increment()
                 log.warn("$LOG_PREFIX:IllegalArgumentException:", exception)
                 listener.onFailure(OpenSearchStatusException(exception.message, RestStatus.BAD_REQUEST))
             } catch (exception: IllegalStateException) {
+                Metrics.OBSERVABILITY_EXCEPTIONS_ILLEGAL_STATE_EXCEPTION.counter.increment()
                 log.warn("$LOG_PREFIX:IllegalStateException:", exception)
                 listener.onFailure(OpenSearchStatusException(exception.message, RestStatus.SERVICE_UNAVAILABLE))
             } catch (exception: IOException) {
+                Metrics.OBSERVABILITY_EXCEPTIONS_IO_EXCEPTION.counter.increment()
                 log.error("$LOG_PREFIX:Uncaught IOException:", exception)
                 listener.onFailure(OpenSearchStatusException(exception.message, RestStatus.FAILED_DEPENDENCY))
             } catch (exception: Exception) {
+                Metrics.OBSERVABILITY_EXCEPTIONS_INTERNAL_SERVER_ERROR.counter.increment()
                 log.error("$LOG_PREFIX:Uncaught Exception:", exception)
                 listener.onFailure(OpenSearchStatusException(exception.message, RestStatus.INTERNAL_SERVER_ERROR))
             }

--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/metrics/BasicCounter.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/metrics/BasicCounter.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.observability.metrics
+
+import java.util.concurrent.atomic.LongAdder
+
+/**
+ * Counter to hold accumulative value over time.
+ */
+class BasicCounter : Counter<Long> {
+    private val count = LongAdder()
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun increment() {
+        count.increment()
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun add(n: Long) {
+        count.add(n)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override val value: Long
+        get() = count.toLong()
+
+    /** Reset the count value to zero */
+    override fun reset() {
+        count.reset()
+    }
+}

--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/metrics/Counter.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/metrics/Counter.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.observability.metrics
+
+/**
+ * Defines a generic counter.
+ */
+interface Counter<T> {
+    /** Increments the count value by 1 unit */
+    fun increment()
+
+    /** Increments the count value by n unit */
+    fun add(n: Long)
+
+    /** Retrieves the count value accumulated upto this call */
+    val value: T
+
+    /** Resets the count value to initial value when Counter is created */
+    fun reset()
+}

--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/metrics/Metrics.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/metrics/Metrics.kt
@@ -20,7 +20,7 @@ enum class Metrics(val metricName: String, val counter: Counter<*>) {
 
     /**
      * Exceptions from:
-     * @see org.opensearch.reportsscheduler.action.PluginBaseAction
+     * @see org.opensearch.observability.action.PluginBaseAction
      */
     OBSERVABILITY_EXCEPTIONS_OPENSEARCH_STATUS_EXCEPTION("exception.opensearch_status", RollingCounter()),
     OBSERVABILITY_EXCEPTIONS_OPENSEARCH_SECURITY_EXCEPTION("exception.opensearch_security", RollingCounter()),

--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/metrics/Metrics.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/metrics/Metrics.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.observability.metrics
+
+import com.github.wnameless.json.unflattener.JsonUnflattener
+import org.json.JSONObject
+
+/**
+ * Enum to hold all the metrics that need to be logged into _plugins/_observability/_local/stats API
+ */
+enum class Metrics(val metricName: String, val counter: Counter<*>) {
+    REQUEST_TOTAL("request_total", BasicCounter()),
+    REQUEST_INTERVAL_COUNT("request_count", RollingCounter()),
+    REQUEST_SUCCESS("success_count", RollingCounter()),
+    REQUEST_USER_ERROR("failed_request_count_user_error", RollingCounter()),
+    REQUEST_SYSTEM_ERROR("failed_request_count_system_error", RollingCounter()),
+
+    /**
+     * Exceptions from:
+     * @see org.opensearch.reportsscheduler.action.PluginBaseAction
+     */
+    OBSERVABILITY_EXCEPTIONS_OPENSEARCH_STATUS_EXCEPTION("exception.opensearch_status", RollingCounter()),
+    OBSERVABILITY_EXCEPTIONS_OPENSEARCH_SECURITY_EXCEPTION("exception.opensearch_security", RollingCounter()),
+    OBSERVABILITY_EXCEPTIONS_VERSION_CONFLICT_ENGINE_EXCEPTION("exception.version_conflict_engine", RollingCounter()),
+    OBSERVABILITY_EXCEPTIONS_INDEX_NOT_FOUND_EXCEPTION("exception.index_not_found", RollingCounter()),
+    OBSERVABILITY_EXCEPTIONS_INVALID_INDEX_NAME_EXCEPTION(
+        "exception.invalid_index_name", RollingCounter()
+    ),
+    OBSERVABILITY_EXCEPTIONS_ILLEGAL_ARGUMENT_EXCEPTION(
+        "exception.illegal_argument", RollingCounter()
+    ),
+    OBSERVABILITY_EXCEPTIONS_ILLEGAL_STATE_EXCEPTION(
+        "exception.illegal_state", RollingCounter()
+    ),
+    OBSERVABILITY_EXCEPTIONS_IO_EXCEPTION(
+        "exception.io", RollingCounter()
+    ),
+    OBSERVABILITY_EXCEPTIONS_INTERNAL_SERVER_ERROR(
+        "exception.internal_server_error", RollingCounter()
+    ),
+
+    OBSERVABILITY_SECURITY_PERMISSION_ERROR("security_permission_error", RollingCounter()),
+    OBSERVABILITY_PERMISSION_USER_ERROR("permission_user_error", RollingCounter());
+
+    companion object {
+        private val values: Array<Metrics> = Metrics.values()
+
+        /**
+         * Converts the enum metric values to JSON string
+         */
+        private fun collectToJSON(): String {
+            val metricsJSONObject = JSONObject()
+            for (metric in values) {
+                metricsJSONObject.put(metric.metricName, metric.counter.value)
+            }
+            return metricsJSONObject.toString()
+        }
+
+        /**
+         * Unflattens the JSON to nested JSON for easy readability and parsing
+         * The metric name is unflattened in the output JSON on the period '.' delimiter
+         *
+         * For ex:  { "a.b.c_d" : 2 } becomes
+         * {
+         *   "a" : {
+         *     "b" : {
+         *       "c_d" : 2
+         *     }
+         *   }
+         * }
+         */
+        fun collectToFlattenedJSON(): String {
+            return JsonUnflattener.unflatten(collectToJSON())
+        }
+    }
+}

--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/metrics/RollingCounter.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/metrics/RollingCounter.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.observability.metrics
+
+import java.time.Clock
+import java.util.concurrent.ConcurrentSkipListMap
+
+/**
+ * Rolling counter. The count is refreshed every interval. In every interval the count is cumulative.
+ */
+internal class RollingCounter(
+    private val window: Long = METRICS_ROLLING_WINDOW_VALUE,
+    private val interval: Long = METRICS_ROLLING_INTERVAL_VALUE,
+    private val clock: Clock = Clock.systemDefaultZone()
+) : Counter<Long> {
+    private val capacity: Long = window / interval * 2
+    private val timeToCountMap = ConcurrentSkipListMap<Long, Long>()
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun increment() {
+        add(1L)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun add(n: Long) {
+        trim()
+        timeToCountMap.compute(
+            getKey(clock.millis())
+        ) { k: Long?, v: Long? -> if (v == null) n else v + n }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override val value get() = getValue(getPreKey(clock.millis()))
+
+    /**
+     * {@inheritDoc}
+     */
+    fun getValue(key: Long): Long {
+        return timeToCountMap[key] ?: return 0
+    }
+
+    private fun trim() {
+        if (timeToCountMap.size > capacity) {
+            timeToCountMap.headMap(getKey(clock.millis() - window * 1000)).clear()
+        }
+    }
+
+    private fun getKey(millis: Long): Long {
+        return millis / 1000 / interval
+    }
+
+    private fun getPreKey(millis: Long): Long {
+        return getKey(millis) - 1
+    }
+
+    /**
+     * Number of existing intervals
+     */
+    fun size(): Int {
+        return timeToCountMap.size
+    }
+
+    /**
+     * Remove all the items from counter
+     */
+    override fun reset() {
+        timeToCountMap.clear()
+    }
+
+    companion object {
+        private const val METRICS_ROLLING_WINDOW_VALUE = 3600L
+        private const val METRICS_ROLLING_INTERVAL_VALUE = 60L
+    }
+}

--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/metrics/RollingCounter.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/metrics/RollingCounter.kt
@@ -50,12 +50,12 @@ internal class RollingCounter(
 
     private fun trim() {
         if (timeToCountMap.size > capacity) {
-            timeToCountMap.headMap(getKey(clock.millis() - window * 1000)).clear()
+            timeToCountMap.headMap(getKey(clock.millis() - window * MILLIS_MULTIPLIER)).clear()
         }
     }
 
     private fun getKey(millis: Long): Long {
-        return millis / 1000 / interval
+        return millis / MILLIS_MULTIPLIER / interval
     }
 
     private fun getPreKey(millis: Long): Long {
@@ -79,5 +79,6 @@ internal class RollingCounter(
     companion object {
         private const val METRICS_ROLLING_WINDOW_VALUE = 3600L
         private const val METRICS_ROLLING_INTERVAL_VALUE = 60L
+        private const val MILLIS_MULTIPLIER = 1000
     }
 }

--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/resthandler/ObservabilityRestHandler.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/resthandler/ObservabilityRestHandler.kt
@@ -200,8 +200,6 @@ internal class ObservabilityRestHandler : BaseRestHandler() {
      * {@inheritDoc}
      */
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
-        Metrics.REQUEST_TOTAL.counter.increment()
-        Metrics.REQUEST_INTERVAL_COUNT.counter.increment()
         return when (request.method()) {
             POST -> executePostRequest(request, client)
             PUT -> executePutRequest(request, client)

--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/resthandler/ObservabilityRestHandler.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/resthandler/ObservabilityRestHandler.kt
@@ -18,7 +18,6 @@ import org.opensearch.observability.action.ObservabilityActions
 import org.opensearch.observability.action.UpdateObservabilityObjectAction
 import org.opensearch.observability.action.UpdateObservabilityObjectRequest
 import org.opensearch.observability.index.ObservabilityQueryHelper
-import org.opensearch.observability.metrics.Metrics
 import org.opensearch.observability.model.ObservabilityObjectType
 import org.opensearch.observability.model.RestTag.FROM_INDEX_FIELD
 import org.opensearch.observability.model.RestTag.MAX_ITEMS_FIELD

--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/resthandler/ObservabilityRestHandler.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/resthandler/ObservabilityRestHandler.kt
@@ -18,6 +18,7 @@ import org.opensearch.observability.action.ObservabilityActions
 import org.opensearch.observability.action.UpdateObservabilityObjectAction
 import org.opensearch.observability.action.UpdateObservabilityObjectRequest
 import org.opensearch.observability.index.ObservabilityQueryHelper
+import org.opensearch.observability.metrics.Metrics
 import org.opensearch.observability.model.ObservabilityObjectType
 import org.opensearch.observability.model.RestTag.FROM_INDEX_FIELD
 import org.opensearch.observability.model.RestTag.MAX_ITEMS_FIELD
@@ -93,7 +94,7 @@ internal class ObservabilityRestHandler : BaseRestHandler() {
              * Response body: Ref [org.opensearch.observability.model.DeleteObservabilityObjectResponse]
              */
             Route(DELETE, "$OBSERVABILITY_URL/{$OBJECT_ID_FIELD}"),
-            Route(DELETE, "$OBSERVABILITY_URL")
+            Route(DELETE, OBSERVABILITY_URL)
         )
     }
 
@@ -199,6 +200,8 @@ internal class ObservabilityRestHandler : BaseRestHandler() {
      * {@inheritDoc}
      */
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
+        Metrics.REQUEST_TOTAL.counter.increment()
+        Metrics.REQUEST_INTERVAL_COUNT.counter.increment()
         return when (request.method()) {
             POST -> executePostRequest(request, client)
             PUT -> executePutRequest(request, client)

--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/resthandler/ObservabilityStatsRestHandler.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/resthandler/ObservabilityStatsRestHandler.kt
@@ -1,0 +1,59 @@
+package org.opensearch.observability.resthandler
+
+import org.opensearch.client.node.NodeClient
+import org.opensearch.observability.ObservabilityPlugin.Companion.BASE_OBSERVABILITY_URI
+import org.opensearch.observability.metrics.Metrics
+import org.opensearch.rest.BaseRestHandler
+import org.opensearch.rest.BaseRestHandler.RestChannelConsumer
+import org.opensearch.rest.BytesRestResponse
+import org.opensearch.rest.RestHandler.Route
+import org.opensearch.rest.RestRequest
+import org.opensearch.rest.RestRequest.Method.GET
+import org.opensearch.rest.RestStatus
+
+/**
+ * Rest handler for getting observability backend stats
+ */
+internal class ObservabilityStatsRestHandler : BaseRestHandler() {
+    companion object {
+        private const val OBSERVABILITY_STATS_ACTION = "observability_stats"
+        private const val OBSERVABILITY_STATS_URL = "$BASE_OBSERVABILITY_URI/_local/stats"
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun getName(): String {
+        return OBSERVABILITY_STATS_ACTION
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun routes(): List<Route> {
+        return listOf(
+            Route(GET, OBSERVABILITY_STATS_URL)
+        )
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun responseParams(): Set<String> {
+        return setOf()
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
+        return when (request.method()) {
+            GET -> RestChannelConsumer {
+                it.sendResponse(BytesRestResponse(RestStatus.OK, Metrics.collectToFlattenedJSON()))
+            }
+            else -> RestChannelConsumer {
+                it.sendResponse(BytesRestResponse(RestStatus.METHOD_NOT_ALLOWED, "${request.method()} is not allowed"))
+            }
+        }
+    }
+}

--- a/opensearch-observability/src/main/kotlin/org/opensearch/observability/resthandler/RestResponseToXContentListener.kt
+++ b/opensearch-observability/src/main/kotlin/org/opensearch/observability/resthandler/RestResponseToXContentListener.kt
@@ -5,8 +5,12 @@
 
 package org.opensearch.observability.resthandler
 
+import org.opensearch.common.xcontent.XContentBuilder
+import org.opensearch.observability.metrics.Metrics
 import org.opensearch.observability.model.BaseResponse
+import org.opensearch.rest.BytesRestResponse
 import org.opensearch.rest.RestChannel
+import org.opensearch.rest.RestResponse
 import org.opensearch.rest.RestStatus
 import org.opensearch.rest.action.RestToXContentListener
 
@@ -16,6 +20,24 @@ import org.opensearch.rest.action.RestToXContentListener
  * (wrapping the toXContent in startObject/endObject).
  */
 internal class RestResponseToXContentListener<Response : BaseResponse>(channel: RestChannel) : RestToXContentListener<Response>(channel) {
+    /**
+     * {@inheritDoc}
+     */
+    override fun buildResponse(response: Response, builder: XContentBuilder?): RestResponse {
+        super.buildResponse(response, builder)
+
+        Metrics.REQUEST_TOTAL.counter.increment()
+        Metrics.REQUEST_INTERVAL_COUNT.counter.increment()
+
+        when (response.getStatus()) {
+            in RestStatus.OK..RestStatus.MULTI_STATUS -> Metrics.REQUEST_SUCCESS.counter.increment()
+            RestStatus.FORBIDDEN -> Metrics.OBSERVABILITY_SECURITY_PERMISSION_ERROR.counter.increment()
+            in RestStatus.UNAUTHORIZED..RestStatus.TOO_MANY_REQUESTS -> Metrics.REQUEST_USER_ERROR.counter.increment()
+            else -> Metrics.REQUEST_SYSTEM_ERROR.counter.increment()
+        }
+        return BytesRestResponse(getStatus(response), builder)
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/opensearch-observability/src/test/kotlin/org/opensearch/observability/metrics/BasicCounterTests.kt
+++ b/opensearch-observability/src/test/kotlin/org/opensearch/observability/metrics/BasicCounterTests.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.observability.metrics
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers
+import org.junit.jupiter.api.Test
+
+internal class BasicCounterTests {
+    @Test
+    fun increment() {
+        val counter = BasicCounter()
+        for (i in 0..4) {
+            counter.increment()
+        }
+        assertThat(counter.value, Matchers.equalTo(5L))
+    }
+
+    @Test
+    fun incrementN() {
+        val counter = BasicCounter()
+        counter.add(5)
+        assertThat(counter.value, Matchers.equalTo(5L))
+    }
+}

--- a/opensearch-observability/src/test/kotlin/org/opensearch/observability/metrics/BasicCounterTests.kt
+++ b/opensearch-observability/src/test/kotlin/org/opensearch/observability/metrics/BasicCounterTests.kt
@@ -13,7 +13,7 @@ internal class BasicCounterTests {
     @Test
     fun increment() {
         val counter = BasicCounter()
-        for (i in 0..4) {
+        for (@Suppress("unused") i in 0..4) {
             counter.increment()
         }
         assertThat(counter.value, Matchers.equalTo(5L))

--- a/opensearch-observability/src/test/kotlin/org/opensearch/observability/metrics/RollingCounterTests.kt
+++ b/opensearch-observability/src/test/kotlin/org/opensearch/observability/metrics/RollingCounterTests.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.observability.metrics
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.Clock
+
+@ExtendWith(MockitoExtension::class)
+internal class RollingCounterTests {
+    @Mock
+    var clock: Clock? = null
+
+    @Test
+    fun increment() {
+        val counter = RollingCounter(3, 1, clock!!)
+        for (i in 0..4) {
+            counter.increment()
+        }
+        assertThat(counter.value, Matchers.equalTo(0L))
+        Mockito.`when`(clock!!.millis()).thenReturn(1000L) // 1 second passed
+        assertThat(counter.value, Matchers.equalTo(5L))
+        counter.increment()
+        counter.increment()
+        Mockito.`when`(clock!!.millis()).thenReturn(2000L) // 1 second passed
+        assertThat(counter.value, Matchers.lessThanOrEqualTo(3L))
+        Mockito.`when`(clock!!.millis()).thenReturn(3000L) // 1 second passed
+        assertThat(counter.value, Matchers.equalTo(0L))
+    }
+
+    @Test
+    fun add() {
+        val counter = RollingCounter(3, 1, clock!!)
+        counter.add(6)
+        assertThat(counter.value, Matchers.equalTo(0L))
+        Mockito.`when`(clock!!.millis()).thenReturn(1000L) // 1 second passed
+        assertThat(counter.value, Matchers.equalTo(6L))
+        counter.add(4)
+        Mockito.`when`(clock!!.millis()).thenReturn(2000L) // 1 second passed
+        assertThat(counter.value, Matchers.equalTo(4L))
+        Mockito.`when`(clock!!.millis()).thenReturn(3000L) // 1 second passed
+        assertThat(counter.value, Matchers.equalTo(0L))
+    }
+
+    @Test
+    fun trim() {
+        val counter = RollingCounter(2, 1, clock!!)
+        for (i in 1..5) {
+            counter.increment()
+            assertThat(counter.size(), Matchers.equalTo(i))
+            Mockito.`when`(clock!!.millis()).thenReturn(i * 1000L) // i seconds passed
+        }
+        counter.increment()
+        assertThat(counter.size(), Matchers.lessThanOrEqualTo(3))
+    }
+}


### PR DESCRIPTION
### Description

- This PR adds the metrics counters and API to both OpenSearch and Dashboards plugins
- Examples to instrument metrics (this PR only adds the framework and basic examples):
  - Increment OpenSearch plugin `REQUEST_TOTAL` counter:
    ```kotlin
    Metrics.REQUEST_TOTAL.counter.increment()
    ```
  - Increment Dashboards plugin Event Analytics create request counter:
    ```typescript
    addRequestToMetric('event_analytics', 'create', 'count');
    ```
  - Increment Dashboards plugin Event Analytics create request error counter:
    ```typescript
    addRequestToMetric('event_analytics', 'create', error);
    ```
  - Increment Dashboards plugin UI button event counter for `{ "trace_analytics": { "refresh_button": count } }` in metrics response:
    ```diff
        <EuiButton
    +    click-metric-element="trace_analytics.refresh_button"
          iconType="refresh"
          onClick={props.refresh}
        >
    ```
- To get metrics

  - OpenSearch plugin: `GET http://localhost:9200/_plugins/_observability/_local/stats`
    <details>
    <summary>Response</summary>

    ```http
    GET http://localhost:9200/_plugins/_observability/_local/stats

    {
      "security_permission_error": 0,
      "exception": {
        "io": 0,
        "opensearch_security": 0,
        "invalid_index_name": 0,
        "index_not_found": 0,
        "internal_server_error": 0,
        "illegal_state": 0,
        "version_conflict_engine": 0,
        "illegal_argument": 0,
        "opensearch_status": 0
      },
      "success_count": 0,
      "permission_user_error": 0,
      "request_total": 0,
      "failed_request_count_system_error": 0,
      "request_count": 0,
      "failed_request_count_user_error": 0
    }
    ```

    </details>

  - Dashboards plugin: `GET http://localhost:5601/api/observability/stats`
    <details>
    <summary>Response</summary>

    ```http
    GET http://localhost:5601/api/observability/stats
    {
      "application_analytics": {
        "create": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        },
        "get": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        },
        "update": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        },
        "delete": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        }
      },
      "operational_panels": {
        "create": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        },
        "get": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        },
        "update": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        },
        "delete": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        }
      },
      "event_analytics": {
        "create": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        },
        "get": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        },
        "update": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        },
        "delete": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        }
      },
      "notebooks": {
        "create": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        },
        "get": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        },
        "update": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        },
        "delete": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        }
      },
      "trace_analytics": {
        "create": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        },
        "get": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        },
        "update": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        },
        "delete": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        }
      },
      "metrics_analytics": {
        "create": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        },
        "get": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        },
        "update": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        },
        "delete": {
          "count": 0,
          "system_error": 0,
          "user_error": 0,
          "total": 0
        }
      },
      "request_total": 0,
      "request_count": 0,
      "success_count": 0,
      "failed_request_count_system_error": 0,
      "failed_request_count_user_error": 0
    }
    ```

    </details>

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
