### PR TITLE
[BACKPORT 1.3] feat: enable windows and macos builds (#1108)

### DIFF
--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -11,8 +11,10 @@ env:
 jobs:
 
   build:
-
-    runs-on: ubuntu-latest
+    strategy: 
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout Plugin
@@ -57,13 +59,13 @@ jobs:
           yarn test --coverage
 
       - name: Upload coverage
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: codecov/codecov-action@v1
         with:
           flags: dashboards-observability
           directory: ./OpenSearch-Dashboards/plugins/dashboards-observability
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      # TODO remove hard coded version when observability is ready
       - name: Build Artifact
         run: |
           cd OpenSearch-Dashboards/plugins/dashboards-observability
@@ -73,6 +75,5 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v1
         with:
-          name: dashboards-observability
+          name: dashboards-observability-${{ matrix.os }}
           path: ./OpenSearch-Dashboards/plugins/dashboards-observability/build
-

--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -12,7 +12,7 @@ jobs:
 
   build:
     strategy: 
-       fail-fast: false
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -49,6 +49,12 @@ jobs:
       - name: Move Observability to Plugins Dir
         run: mv dashboards-observability OpenSearch-Dashboards/plugins/dashboards-observability
 
+      - name: Fix node for mac
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: |
+          sudo rm -rf  /Library/Developer/CommandLineTools
+          xcode-select --install
+
       - name: Plugin Bootstrap
         run: |
           cd OpenSearch-Dashboards/plugins/dashboards-observability

--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -14,7 +14,7 @@ jobs:
     strategy: 
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -48,12 +48,6 @@ jobs:
 
       - name: Move Observability to Plugins Dir
         run: mv dashboards-observability OpenSearch-Dashboards/plugins/dashboards-observability
-
-      - name: Fix node for mac
-        if: ${{ matrix.os == 'macos-latest' }}
-        run: |
-          sudo rm -rf  /Library/Developer/CommandLineTools
-          xcode-select --install
 
       - name: Plugin Bootstrap
         run: |

--- a/.github/workflows/dashboards-observability-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-observability-test-and-build-workflow.yml
@@ -12,6 +12,7 @@ jobs:
 
   build:
     strategy: 
+       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/opensearch-observability-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-observability-test-and-build-workflow.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build with Gradle
         run: |
           cd opensearch-observability
-          ./gradlew build -Dopensearch.version=${{ env.OPENSEARCH_VERSION }} ${{ env.BUILD_ARGS }}
+          ./gradlew build ${{ env.BUILD_ARGS }}
 
       - name: Upload coverage
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/opensearch-observability-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-observability-test-and-build-workflow.yml
@@ -13,7 +13,7 @@ jobs:
       BUILD_ARGS: ${{ matrix.os_build_args }}
     strategy:
       matrix:
-        java: [8, 11, 17]
+        java: [8, 11]
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: windows-latest

--- a/.github/workflows/opensearch-observability-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-observability-test-and-build-workflow.yml
@@ -9,14 +9,18 @@ env:
 
 jobs:
   build:
+    env:
+      BUILD_ARGS: ${{ matrix.os_build_args }}
     strategy:
       matrix:
-        java:
-          - 8
-          - 11
-          - 14
-
-    runs-on: ubuntu-latest
+        java: [8, 11, 17]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: windows-latest
+            os_build_args: -x integTest -x jacocoTestReport
+          - os: macos-latest
+            os_build_args: -x integTest -x jacocoTestReport
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v1
@@ -27,6 +31,8 @@ jobs:
           java-version: ${{ matrix.java }}
     
       - name: Run Backwards Compatibility Tests
+        # Temporarily only do this for linux
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
           cd opensearch-observability
           echo "Running backwards compatibility tests ..."
@@ -35,9 +41,10 @@ jobs:
       - name: Build with Gradle
         run: |
           cd opensearch-observability
-          ./gradlew build -Dopensearch.version=${{ env.OPENSEARCH_VERSION }}
+          ./gradlew build -Dopensearch.version=${{ env.OPENSEARCH_VERSION }} ${{ env.BUILD_ARGS }}
 
       - name: Upload coverage
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: codecov/codecov-action@v1
         with:
           flags: opensearch-observability
@@ -52,5 +59,5 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v1
         with:
-          name: opensearch-observability
+          name: opensearch-observability-${{ matrix.os }}
           path: opensearch-observability-builds

--- a/dashboards-observability/public/components/explorer/no_results.tsx
+++ b/dashboards-observability/public/components/explorer/no_results.tsx
@@ -38,8 +38,7 @@ export const NoResults = () => {
                 <p>
                   <FormattedMessage
                     id="discover.noResults.queryMayNotMatchTitle"
-                    defaultMessage="Your query may not match anything in the current time range, or there may not be any data at all in
-                    the currently selected time range. Try change time range, query filters or choose different time fields"
+                    defaultMessage="Your query may not match anything in the current time range, or there may not be any data at all in the currently selected time range. Try change time range, query filters or choose different time fields"
                   />
                 </p>
               </EuiText>


### PR DESCRIPTION

(cherry picked from commit 363ccd4946fcbb9280078e694846e9aa8a8753b0)
Signed-off-by: Derek Ho <dxho@amazon.com>

### Description
[Describe what this change achieves]

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
