### PR TITLE
Revert "Removing explicit jackson dependencies (#1374)"

### DIFF
--- a/opensearch-observability/build.gradle
+++ b/opensearch-observability/build.gradle
@@ -23,6 +23,7 @@ buildscript {
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
         kotlin_version = System.getProperty("kotlin.version", "1.6.0")
         job_scheduler_version = System.getProperty("job_scheduler.version", opensearch_build)
+        jackson_version = "2.14.1"
     }
 
     repositories {
@@ -115,6 +116,7 @@ configurations.all {
     resolutionStrategy {
         force "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
         force "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
+        force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jackson_version}"
         force "org.mockito:mockito-core:4.6.1"
     }
 }
@@ -158,8 +160,11 @@ dependencies {
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     implementation 'org.json:json:20220924'
     implementation group: 'com.github.wnameless.json', name: 'json-flattener', version: '0.15.1'
-    // jackson is coming from core now, https://github.com/opensearch-project/opensearch-plugins/issues/191
+    // json-base, jackson-databind, jackson-annotations are only used by json-flattener.
+    // see https://github.com/opensearch-project/OpenSearch/issues/5395.
     implementation group: 'com.github.wnameless.json', name: 'json-base', version: '2.2.1'
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:${jackson_version}"
     compileOnly "${group}:opensearch-job-scheduler-spi:${job_scheduler_version}"
     testImplementation(
             'org.assertj:assertj-core:3.16.1',


### PR DESCRIPTION
This reverts commit 04c5f061ca8c1112faa60d516a57775b08ed8fa1.

### Description
Jackson is no longer in core, reverting changes made to remove it

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
  - [X] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
