### PR TITLE
Automate releases based on tagging

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,29 @@
+name: Releases
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.5.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+      - name: Get tag
+        id: tag
+        uses: dawidd6/action-get-tag@v1
+      - uses: actions/checkout@v2
+      - uses: ncipollo/release-action@v1
+        with:
+          github_token: ${{ steps.github_app_token.outputs.token }}
+          bodyFile: release-notes/opensearch-observability.release-notes-${{steps.tag.outputs.tag}}.md

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,0 +1,13 @@
+name: Enforce PR labels
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+jobs:
+  enforce-label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: yogevbd/enforce-label-action@2.1.0
+      with:
+        REQUIRED_LABELS_ANY: "breaking,feature,enhancement,bug,infrastructure,dependencies,documentation,maintenance,skip-changelog"
+        REQUIRED_LABELS_ANY_DESCRIPTION: "A release label is required: ['breaking', 'bug', 'dependencies', 'documentation', 'enhancement', 'feature', 'infrastructure', 'maintenance', 'skip-changelog']"

--- a/.github/workflows/opensearch-observability-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-observability-test-and-build-workflow.yml
@@ -4,10 +4,19 @@ on: [pull_request, push]
 
 jobs:
   build:
+    env:
+      BUILD_ARGS: ${{ matrix.os_build_args }}
     strategy:
+      # Run all jobs
+      fail-fast: false
       matrix:
         java: [11, 17]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: windows-latest
+            os_build_args: -x integTest -x jacocoTestReport
+          - os: macos-latest
+            os_build_args: -x integTest -x jacocoTestReport
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -27,7 +36,7 @@ jobs:
 
       - name: Build with Gradle
         run: |
-          ./gradlew build
+          ./gradlew build ${{ env.BUILD_ARGS }}
 
       - name: Upload coverage
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/opensearch-observability-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-observability-test-and-build-workflow.yml
@@ -4,19 +4,10 @@ on: [pull_request, push]
 
 jobs:
   build:
-    env:
-      BUILD_ARGS: ${{ matrix.os_build_args }}
     strategy:
-      # Run all jobs
-      fail-fast: false
       matrix:
         java: [11, 17]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        include:
-          - os: windows-latest
-            os_build_args: -x integTest -x jacocoTestReport
-          - os: macos-latest
-            os_build_args: -x integTest -x jacocoTestReport
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -36,7 +27,7 @@ jobs:
 
       - name: Build with Gradle
         run: |
-          ./gradlew build ${{ env.BUILD_ARGS }}
+          ./gradlew build
 
       - name: Upload coverage
         if: ${{ matrix.os == 'ubuntu-latest' }}


### PR DESCRIPTION
### Description
Rebasing #1410 onto the `2.x` branch.

Generating a GitHub Release involves a few steps: selecting the commit, creating a version bump, and creating the release notes file. Per work mentioned in #1406, this has been automated to be performed based on tag selection. This PR:
- Modifies the release label policy in `draft-release-notes-config.yml` to better reflect labels currently in use
	- Includes two new labels, `infrastructure` and `skip-changelog`, that need to be added to the repo
- Implements the auto-release workflow from [OpenSearch/auto-release.yml at main · opensearch-project/OpenSearch](https://github.com/opensearch-project/OpenSearch/blob/1540e00397a19f41d6e92248a3d51d1544255e3f/.github/workflows/auto-release.yml), see `auto-release.yml`
- Adds a policy for enforcing that future PRs are appropriately labeled for more robust release notes, see `enforce-labels.yml`

### Issues Resolved
- Resolves #1406

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
