### PR TITLE
Pull jackson,mockito versions from upstream

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ buildscript {
         }
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
         kotlin_version = System.getProperty("kotlin.version", "1.8.21")
-        jackson_version = "2.14.1"
     }
 
     repositories {
@@ -125,9 +124,9 @@ configurations.all {
     resolutionStrategy {
         force "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
         force "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
-        force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${jackson_version}"
-        force "org.mockito:mockito-core:4.6.1"
-        force "org.yaml:snakeyaml:2.0"
+        force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${versions.jackson}"
+        force "org.mockito:mockito-core:${versions.mockito}"
+        force "org.yaml:snakeyaml:${versions.snakeyaml}"
     }
 }
 
@@ -172,8 +171,8 @@ dependencies {
     // json-base, jackson-databind, jackson-annotations are only used by json-flattener.
     // see https://github.com/opensearch-project/OpenSearch/issues/5395.
     implementation group: 'com.github.wnameless.json', name: 'json-base', version: '2.2.1'
-    implementation "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
-    implementation "com.fasterxml.jackson.core:jackson-annotations:${jackson_version}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
     testImplementation(
             'org.assertj:assertj-core:3.16.1',
             'org.junit.jupiter:junit-jupiter-api:5.6.2'
@@ -182,8 +181,8 @@ dependencies {
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
-    testImplementation "org.mockito:mockito-core:4.3.1"
-    testImplementation "org.mockito:mockito-junit-jupiter:4.3.1"
+    testImplementation "org.mockito:mockito-core:${versions.mockito}"
+    testImplementation "org.mockito:mockito-junit-jupiter:${versions.mockito}"
     testImplementation "com.google.code.gson:gson:2.8.9"
 
     ktlint "com.pinterest:ktlint:0.45.0"


### PR DESCRIPTION
### Description
- pull available dependencies from upstream to remove dev overhead
- https://github.com/opensearch-project/OpenSearch/blob/main/buildSrc/version.properties
- Including: jackson, mockito

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
