### PR TITLE
Upgrade JSON to 20231013 to fix CVE-2023-5072

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9"
     implementation "${group}:common-utils:${common_utils_version}"
-    implementation 'org.json:json:20230227'
+    implementation 'org.json:json:20231013'
     implementation group: 'com.github.wnameless.json', name: 'json-flattener', version: '0.15.1'
     // json-base, jackson-databind, jackson-annotations are only used by json-flattener.
     // see https://github.com/opensearch-project/OpenSearch/issues/5395.


### PR DESCRIPTION
### Description
Upgrade JSON to 20231013 to fix CVE-2023-5072


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
