### PR TITLE
[SECURITY] CVE-2023-6378 and CVE-2023-6481 fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,6 +129,7 @@ configurations.all {
         force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:${versions.jackson}"
         force "org.mockito:mockito-core:${versions.mockito}"
         force "org.yaml:snakeyaml:${versions.snakeyaml}"
+        force "org.slf4j:slf4j-api:2.0.0"
     }
 }
 
@@ -187,7 +188,7 @@ dependencies {
     testImplementation "org.mockito:mockito-junit-jupiter:${versions.mockito}"
     testImplementation "com.google.code.gson:gson:2.8.9"
 
-    ktlint "com.pinterest:ktlint:0.45.0"
+    ktlint "com.pinterest:ktlint:0.47.1"
 }
 
 javadoc.enabled = false // turn off javadoc as it barfs on Kotlin code

--- a/src/main/kotlin/org/opensearch/observability/ObservabilityPlugin.kt
+++ b/src/main/kotlin/org/opensearch/observability/ObservabilityPlugin.kt
@@ -92,7 +92,7 @@ class ObservabilityPlugin : Plugin(), ActionPlugin {
     ): List<RestHandler> {
         return listOf(
             ObservabilityRestHandler(),
-            ObservabilityStatsRestHandler(),
+            ObservabilityStatsRestHandler()
         )
     }
 

--- a/src/main/kotlin/org/opensearch/observability/metrics/Metrics.kt
+++ b/src/main/kotlin/org/opensearch/observability/metrics/Metrics.kt
@@ -27,19 +27,24 @@ enum class Metrics(val metricName: String, val counter: Counter<*>) {
     OBSERVABILITY_EXCEPTIONS_VERSION_CONFLICT_ENGINE_EXCEPTION("exception.version_conflict_engine", RollingCounter()),
     OBSERVABILITY_EXCEPTIONS_INDEX_NOT_FOUND_EXCEPTION("exception.index_not_found", RollingCounter()),
     OBSERVABILITY_EXCEPTIONS_INVALID_INDEX_NAME_EXCEPTION(
-        "exception.invalid_index_name", RollingCounter()
+        "exception.invalid_index_name",
+        RollingCounter()
     ),
     OBSERVABILITY_EXCEPTIONS_ILLEGAL_ARGUMENT_EXCEPTION(
-        "exception.illegal_argument", RollingCounter()
+        "exception.illegal_argument",
+        RollingCounter()
     ),
     OBSERVABILITY_EXCEPTIONS_ILLEGAL_STATE_EXCEPTION(
-        "exception.illegal_state", RollingCounter()
+        "exception.illegal_state",
+        RollingCounter()
     ),
     OBSERVABILITY_EXCEPTIONS_IO_EXCEPTION(
-        "exception.io", RollingCounter()
+        "exception.io",
+        RollingCounter()
     ),
     OBSERVABILITY_EXCEPTIONS_INTERNAL_SERVER_ERROR(
-        "exception.internal_server_error", RollingCounter()
+        "exception.internal_server_error",
+        RollingCounter()
     ),
 
     OBSERVABILITY_SECURITY_PERMISSION_ERROR("security_permission_error", RollingCounter()),

--- a/src/main/kotlin/org/opensearch/observability/model/SavedQuery.kt
+++ b/src/main/kotlin/org/opensearch/observability/model/SavedQuery.kt
@@ -241,7 +241,7 @@ internal data class SavedQuery(
 
     internal data class Token(
         val name: String,
-        val type: String,
+        val type: String
     ) : BaseModel {
         internal companion object {
             private const val NAME_TAG = "name"
@@ -291,7 +291,7 @@ internal data class SavedQuery(
          */
         constructor(input: StreamInput) : this(
             name = input.readString(),
-            type = input.readString(),
+            type = input.readString()
         )
 
         /**

--- a/src/main/kotlin/org/opensearch/observability/model/SavedVisualization.kt
+++ b/src/main/kotlin/org/opensearch/observability/model/SavedVisualization.kt
@@ -69,7 +69,7 @@ internal data class SavedVisualization(
     val subType: String?,
     val metricType: String? = null,
     val unitsOfMeasure: String? = null,
-    val selectedLabels: SelectedLabels? = null,
+    val selectedLabels: SelectedLabels? = null
 ) : BaseObjectData {
 
     internal companion object {
@@ -155,7 +155,7 @@ internal data class SavedVisualization(
                 subType,
                 metricType,
                 unitsOfMeasure,
-                selectedLabels,
+                selectedLabels
             )
         }
     }
@@ -186,7 +186,7 @@ internal data class SavedVisualization(
         subType = input.readString(),
         metricType = input.readOptionalString(),
         unitsOfMeasure = input.readOptionalString(),
-        selectedLabels = input.readOptionalWriteable(SelectedLabels.reader),
+        selectedLabels = input.readOptionalWriteable(SelectedLabels.reader)
     )
 
     /**
@@ -231,7 +231,7 @@ internal data class SavedVisualization(
     }
 
     internal data class Token(
-        val label: String,
+        val label: String
     ) : BaseModel {
         internal companion object {
             private const val LABEL_TAG = "label"
@@ -276,7 +276,7 @@ internal data class SavedVisualization(
          * @param input StreamInput stream to deserialize data from.
          */
         constructor(input: StreamInput) : this(
-            label = input.readString(),
+            label = input.readString()
         )
 
         /**
@@ -299,7 +299,7 @@ internal data class SavedVisualization(
     }
 
     internal data class SelectedLabels(
-        val labels: List<Token>?,
+        val labels: List<Token>?
     ) : BaseModel {
         internal companion object {
             private const val LABELS_TAG = "labels"

--- a/src/main/kotlin/org/opensearch/observability/model/Timestamp.kt
+++ b/src/main/kotlin/org/opensearch/observability/model/Timestamp.kt
@@ -34,7 +34,7 @@ internal data class Timestamp(
     val name: String?,
     val index: String?,
     val type: String?,
-    val dslType: String?,
+    val dslType: String?
 ) : BaseObjectData {
 
     internal companion object {

--- a/src/main/kotlin/org/opensearch/observability/settings/PluginSettings.kt
+++ b/src/main/kotlin/org/opensearch/observability/settings/PluginSettings.kt
@@ -283,61 +283,70 @@ internal object PluginSettings {
         OPERATION_TIMEOUT_MS_KEY,
         defaultSettings[OPERATION_TIMEOUT_MS_KEY]!!.toLong(),
         MINIMUM_OPERATION_TIMEOUT_MS,
-        NodeScope, Dynamic
+        NodeScope,
+        Dynamic
     )
 
     private val JOB_LOCK_DURATION_S: Setting<Int> = Setting.intSetting(
         JOB_LOCK_DURATION_S_KEY,
         defaultSettings[JOB_LOCK_DURATION_S_KEY]!!.toInt(),
         MINIMUM_JOB_LOCK_DURATION_S,
-        NodeScope, Dynamic
+        NodeScope,
+        Dynamic
     )
 
     private val MIN_POLLING_DURATION_S: Setting<Int> = Setting.intSetting(
         MIN_POLLING_DURATION_S_KEY,
         defaultSettings[MIN_POLLING_DURATION_S_KEY]!!.toInt(),
         MINIMUM_MIN_POLLING_DURATION_S,
-        NodeScope, Dynamic
+        NodeScope,
+        Dynamic
     )
 
     private val MAX_POLLING_DURATION_S: Setting<Int> = Setting.intSetting(
         MAX_POLLING_DURATION_S_KEY,
         defaultSettings[MAX_POLLING_DURATION_S_KEY]!!.toInt(),
         MINIMUM_MAX_POLLING_DURATION_S,
-        NodeScope, Dynamic
+        NodeScope,
+        Dynamic
     )
 
     private val MAX_LOCK_RETRIES: Setting<Int> = Setting.intSetting(
         MAX_LOCK_RETRIES_KEY,
         defaultSettings[MAX_LOCK_RETRIES_KEY]!!.toInt(),
         MINIMUM_LOCK_RETRIES,
-        NodeScope, Dynamic
+        NodeScope,
+        Dynamic
     )
 
     private val DEFAULT_ITEMS_QUERY_COUNT: Setting<Int> = Setting.intSetting(
         DEFAULT_ITEMS_QUERY_COUNT_KEY,
         defaultSettings[DEFAULT_ITEMS_QUERY_COUNT_KEY]!!.toInt(),
         MINIMUM_ITEMS_QUERY_COUNT,
-        NodeScope, Dynamic
+        NodeScope,
+        Dynamic
     )
 
     private val ADMIN_ACCESS: Setting<String> = Setting.simpleString(
         ADMIN_ACCESS_KEY,
         defaultSettings[ADMIN_ACCESS_KEY]!!,
-        NodeScope, Dynamic
+        NodeScope,
+        Dynamic
     )
 
     private val FILTER_BY: Setting<String> = Setting.simpleString(
         FILTER_BY_KEY,
         defaultSettings[FILTER_BY_KEY]!!,
-        NodeScope, Dynamic
+        NodeScope,
+        Dynamic
     )
 
     private val IGNORED_ROLES: Setting<List<String>> = Setting.listSetting(
         IGNORE_ROLE_KEY,
         DEFAULT_IGNORED_ROLES,
         { it },
-        NodeScope, Dynamic
+        NodeScope,
+        Dynamic
     )
 
     /**

--- a/src/test/kotlin/org/opensearch/observability/PluginRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/observability/PluginRestTestCase.kt
@@ -62,7 +62,8 @@ abstract class PluginRestTestCase : OpenSearchRestTestCase() {
         val response = client().performRequest(Request("GET", "/_cat/indices?format=json&expand_wildcards=all"))
         val xContentType = MediaType.fromMediaType(response.entity.contentType)
         xContentType.xContent().createParser(
-            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+            NamedXContentRegistry.EMPTY,
+            DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
             response.entity.content
         ).use { parser ->
             for (index in parser.list()) {

--- a/src/test/kotlin/org/opensearch/observability/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/observability/TestHelpers.kt
@@ -73,6 +73,7 @@ fun constructNotebookRequest(name: String = "test notebook"): String {
         }
     """.trimIndent()
 }
+
 @Suppress("MaxLineLength")
 fun constructSavedQueryRequest(name: String = "test saved query"): String {
     return """
@@ -101,6 +102,7 @@ fun constructSavedQueryRequest(name: String = "test saved query"): String {
         }
     """.trimIndent()
 }
+
 @Suppress("MaxLineLength")
 fun constructSavedVisualizationRequest(name: String = "test saved visualization"): String {
     return """


### PR DESCRIPTION
### Description
`ktlint:0.45.0` contains problematic `logback` libraries, bumping `ktlint` to `0.47.1` and resolving the breaking linter changes. Duplicate of #1791 

### Issues Resolved
#1780 #1781 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
