### PR TITLE
Register system index descriptors through SystemIndexPlugin.getSystemIndexDescriptors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -308,7 +308,7 @@ testClusters.integTest {
     setting 'path.repo', repo.absolutePath
 }
 
-String baseVersion = "2.15.0"
+String baseVersion = "2.16.0"
 String bwcVersion = baseVersion + ".0"
 String baseName = "obsBwcCluster"
 String bwcFilePath = "src/test/resources/bwc/"

--- a/src/main/kotlin/org/opensearch/observability/ObservabilityPlugin.kt
+++ b/src/main/kotlin/org/opensearch/observability/ObservabilityPlugin.kt
@@ -64,7 +64,8 @@ class ObservabilityPlugin : Plugin(), ActionPlugin, SystemIndexPlugin {
      */
     override fun getSystemIndexDescriptors(settings: Settings): Collection<SystemIndexDescriptor> {
         return listOf(
-            SystemIndexDescriptor(ObservabilityIndex.INDEX_NAME, "Observability Plugin system index pattern")
+            SystemIndexDescriptor(ObservabilityIndex.INDEX_NAME, "Observability Plugin Configuration index"),
+            SystemIndexDescriptor(ObservabilityIndex.NOTEBOOKS_INDEX_NAME, "Observability Plugin Notebooks index")
         )
     }
 

--- a/src/main/kotlin/org/opensearch/observability/ObservabilityPlugin.kt
+++ b/src/main/kotlin/org/opensearch/observability/ObservabilityPlugin.kt
@@ -19,6 +19,7 @@ import org.opensearch.core.common.io.stream.NamedWriteableRegistry
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.env.Environment
 import org.opensearch.env.NodeEnvironment
+import org.opensearch.indices.SystemIndexDescriptor
 import org.opensearch.observability.action.CreateObservabilityObjectAction
 import org.opensearch.observability.action.DeleteObservabilityObjectAction
 import org.opensearch.observability.action.GetObservabilityObjectAction
@@ -29,6 +30,7 @@ import org.opensearch.observability.resthandler.ObservabilityStatsRestHandler
 import org.opensearch.observability.settings.PluginSettings
 import org.opensearch.plugins.ActionPlugin
 import org.opensearch.plugins.Plugin
+import org.opensearch.plugins.SystemIndexPlugin
 import org.opensearch.repositories.RepositoriesService
 import org.opensearch.rest.RestController
 import org.opensearch.rest.RestHandler
@@ -41,7 +43,7 @@ import java.util.function.Supplier
  * Entry point of the OpenSearch Observability plugin.
  * This class initializes the rest handlers.
  */
-class ObservabilityPlugin : Plugin(), ActionPlugin {
+class ObservabilityPlugin : Plugin(), ActionPlugin, SystemIndexPlugin {
 
     companion object {
         const val PLUGIN_NAME = "opensearch-observability"
@@ -55,6 +57,15 @@ class ObservabilityPlugin : Plugin(), ActionPlugin {
      */
     override fun getSettings(): List<Setting<*>> {
         return PluginSettings.getAllSettings()
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun getSystemIndexDescriptors(settings: Settings): Collection<SystemIndexDescriptor> {
+        return listOf(
+            SystemIndexDescriptor(ObservabilityIndex.INDEX_NAME, "Observability Plugin system index pattern")
+        )
     }
 
     /**

--- a/src/main/kotlin/org/opensearch/observability/index/ObservabilityIndex.kt
+++ b/src/main/kotlin/org/opensearch/observability/index/ObservabilityIndex.kt
@@ -50,7 +50,7 @@ import java.util.concurrent.TimeUnit
 @Suppress("TooManyFunctions")
 internal object ObservabilityIndex {
     private val log by logger(ObservabilityIndex::class.java)
-    private const val INDEX_NAME = ".opensearch-observability"
+    const val INDEX_NAME = ".opensearch-observability"
     private const val NOTEBOOKS_INDEX_NAME = ".opensearch-notebooks"
     private const val OBSERVABILITY_MAPPING_FILE_NAME = "observability-mapping.yml"
     private const val OBSERVABILITY_SETTINGS_FILE_NAME = "observability-settings.yml"

--- a/src/main/kotlin/org/opensearch/observability/index/ObservabilityIndex.kt
+++ b/src/main/kotlin/org/opensearch/observability/index/ObservabilityIndex.kt
@@ -51,7 +51,7 @@ import java.util.concurrent.TimeUnit
 internal object ObservabilityIndex {
     private val log by logger(ObservabilityIndex::class.java)
     const val INDEX_NAME = ".opensearch-observability"
-    private const val NOTEBOOKS_INDEX_NAME = ".opensearch-notebooks"
+    const val NOTEBOOKS_INDEX_NAME = ".opensearch-notebooks"
     private const val OBSERVABILITY_MAPPING_FILE_NAME = "observability-mapping.yml"
     private const val OBSERVABILITY_SETTINGS_FILE_NAME = "observability-settings.yml"
 


### PR DESCRIPTION
### Description

This PR registers the system indices in this plugin through the SystemIndexPlugin extension point in core. These indices will not be functionally different than they are today, its just a formal registration as a system index.

### Issues Resolved

Related to: https://github.com/opensearch-project/security/issues/4439

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
  - [X] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
