### PR TITLE
Bump Java to 21

### DIFF
--- a/.github/workflows/opensearch-observability-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-observability-test-and-build-workflow.yml
@@ -14,7 +14,7 @@ jobs:
       # Run all jobs
       fail-fast: false
       matrix:
-        java: [11, 17, 21]
+        java: [21]
     runs-on: ubuntu-latest
     container:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
@@ -65,7 +65,7 @@ jobs:
       # Run all jobs
       fail-fast: false
       matrix:
-        java: [11, 17, 21]
+        java: [21]
         os: [windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/opensearch-observability-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-observability-test-and-build-workflow.yml
@@ -23,6 +23,9 @@ jobs:
       # need to switch to root so that github actions can install runner binary on container without permission issues.
       options: --user root
 
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
     steps:
       - uses: actions/checkout@v1
 


### PR DESCRIPTION
### Description
Bump Java to 21. Adds unsecure flag to prevent build failures. 

### Issues Resolved
Fix: #1830 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
