### PR TITLE
Bump jdk to 21 for maven snapshot build

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 11
+          java-version: 21
       - uses: actions/checkout@v3
       - uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,19 +16,18 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Peter Fitzgibbons | [pjfitzgibbons](https://github.com/pjfitzgibbons) | Amazon      |
 | Simeon Widdis     | [swiddis](https://github.com/swiddis)             | Amazon      |
 | Chen Dai          | [dai-chen](https://github.com/dai-chen)           | Amazon      |
-| Vamsi Manohar     | [vamsi-amazon](https://github.com/vamsi-amazon)   | Amazon      |
+| Vamsi Manohar     | [vamsi-amazon](https://github.com/vamsimanohar)   | Amazon      |
 | Peng Huo          | [penghuo](https://github.com/penghuo)             | Amazon      |
 | Sean Kao          | [seankao-az](https://github.com/seankao-az)       | Amazon      |
 | Anirudha Jadhav   | [anirudha](https://github.com/anirudha)           | Amazon      |
 
-
 ## Emeritus Maintainers
 
-| Maintainer        | GitHub ID                                               | Affiliation |
-| ----------------- | ------------------------------------------------------- | ----------- |
-| Charlotte Henkle  | [CEHENKLE](https://github.com/CEHENKLE)                 | Amazon      |
-| Nick Knize        | [nknize](https://github.com/nknize)                     | Amazon      |
-| David Cui         | [davidcui1225](https://github.com/davidcui1225)         | Amazon      |
-| Eugene Lee        | [eugenesk24](https://github.com/eugenesk24)             | Amazon      |
-| Zhongnan Su       | [zhongnansu](https://github.com/zhongnansu)             | Amazon      |
-| Sean Li           | [sejli](https://github.com/sejli)                       | Amazon      |
+| Maintainer       | GitHub ID                                       | Affiliation |
+| ---------------- | ----------------------------------------------- | ----------- |
+| Charlotte Henkle | [CEHENKLE](https://github.com/CEHENKLE)         | Amazon      |
+| Nick Knize       | [nknize](https://github.com/nknize)             | Amazon      |
+| David Cui        | [davidcui1225](https://github.com/davidcui1225) | Amazon      |
+| Eugene Lee       | [eugenesk24](https://github.com/eugenesk24)     | Amazon      |
+| Zhongnan Su      | [zhongnansu](https://github.com/zhongnansu)     | Amazon      |
+| Sean Li          | [sejli](https://github.com/sejli)               | Amazon      |


### PR DESCRIPTION
### Description
Bump jdk to 21 for maven snapshot build. This is blocking dashboards-observability CIs https://github.com/opensearch-project/dashboards-observability/actions/runs/13530139949/job/37810149870?pr=2364

### Related Issues
https://github.com/opensearch-project/observability/issues/1908

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/observability/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
