### PR TITLE
Using java-agent gradle plugin to phase off Security Manager in favor of Java-agent.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ apply plugin: 'opensearch.testclusters'
 apply plugin: 'io.gitlab.arturbosch.detekt'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.plugin.allopen'
+apply plugin: 'opensearch.java-agent'
 
 def usingRemoteCluster = System.properties.containsKey('tests.rest.cluster') || System.properties.containsKey('tests.cluster')
 def usingMultiNode = project.properties.containsKey('numNodes')

--- a/build.gradle
+++ b/build.gradle
@@ -179,26 +179,6 @@ allprojects {
     plugins.withId('java') {
         sourceCompatibility = targetCompatibility = "21"
     }
-
-    configurations {
-        agent
-    }
-    
-    task prepareAgent(type: Copy) {
-        from(configurations.agent)
-        into "$buildDir/agent"
-    }
-
-    dependencies {
-        agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
-        agent "org.opensearch:opensearch-agent:${opensearch_version}"
-        agent "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
-    }
-
-    tasks.withType(Test) {
-        dependsOn prepareAgent
-        jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
-    }
 }
 
 dependencies {


### PR DESCRIPTION
### Description
Using java-agent gradle plugin to phase off Security Manager in favor of Java-agent.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/observability/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
