### PR TITLE
Fix node crash on GET /_observability/_local/stats caused by Jackson databind mismatch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -217,10 +217,16 @@ dependencies {
     implementation "${group}:common-utils:${common_utils_version}"
     implementation 'org.json:json:20231013'
     implementation group: 'com.github.wnameless.json', name: 'json-flattener', version: '0.15.1'
-    // json-base, jackson-databind, jackson-annotations are only used by json-flattener.
+    // json-base, jackson-core, jackson-databind, jackson-annotations are only used by json-flattener.
     // see https://github.com/opensearch-project/OpenSearch/issues/5395.
+    // json-flattener 0.15.1 is built against Jackson 2.x, so the full com.fasterxml Jackson 2.x
+    // stack (core, databind, annotations) must be bundled with the plugin. Core no longer exports
+    // com.fasterxml Jackson 2.x on the plugin classpath after its move to tools.jackson 3.x, so
+    // without these the stats endpoint throws NoClassDefFoundError and exits the node. Keep the
+    // versions aligned with the sql and alerting plugins.
     implementation group: 'com.github.wnameless.json', name: 'json-base', version: '2.2.1'
-    implementation "tools.jackson.core:jackson-databind:${versions.jackson3}"
+    implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"
     testImplementation(
             'org.assertj:assertj-core:3.27.7',

--- a/src/test/kotlin/org/opensearch/observability/rest/ObservabilityStatsIT.kt
+++ b/src/test/kotlin/org/opensearch/observability/rest/ObservabilityStatsIT.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.observability.rest
+
+import org.junit.Assert
+import org.opensearch.core.rest.RestStatus
+import org.opensearch.observability.ObservabilityPlugin.Companion.BASE_OBSERVABILITY_URI
+import org.opensearch.observability.PluginRestTestCase
+import org.opensearch.rest.RestRequest
+
+class ObservabilityStatsIT : PluginRestTestCase() {
+    /**
+     * Regression test for the node crash on GET /_plugins/_observability/_local/stats.
+     *
+     * The stats endpoint flattens its metrics through json-flattener, which is built against
+     * Jackson 2.x and loads com.fasterxml.jackson.databind.ObjectMapper at runtime. Bundling
+     * only the Jackson 3.x (tools.jackson) databind made this call throw NoClassDefFoundError
+     * on an uncaught-exception thread, which tripped OpenSearchUncaughtExceptionHandler and
+     * exited the node process. This test runs against the installed plugin distribution, so a
+     * Jackson databind classpath mismatch takes the node down and fails here instead of shipping.
+     */
+    fun `test local stats endpoint responds without crashing the node`() {
+        val statsResponse =
+            executeRequest(
+                RestRequest.Method.GET.name,
+                "$BASE_OBSERVABILITY_URI/_local/stats",
+                "",
+                RestStatus.OK.status,
+            )
+        // Assert the json-flattener unflatten path actually produced output. A flat counter
+        // such as request_total stays top level, while exception.* keys are nested under
+        // exception, which only happens if JsonUnflattener ran successfully on the classpath.
+        Assert.assertTrue(
+            "Stats response should contain the request_total counter",
+            statsResponse.has("request_total"),
+        )
+        Assert.assertTrue(
+            "Stats response should contain the nested exception counters",
+            statsResponse.has("exception"),
+        )
+    }
+}


### PR DESCRIPTION
### Problem

GET /_plugins/_observability/_local/stats throws NoClassDefFoundError for a com/fasterxml/jackson class on an uncaught-exception thread, which trips OpenSearchUncaughtExceptionHandler and exits the node process. A single well-formed read request takes the node down, so any caller or monitoring that polls this endpoint can crash nodes repeatedly. This is what fails the 3.8.0 default suite in the opensearch-api-specification matrix: the spec passes (0 assertion failures across 302 stories), but the stats call crashes the cluster mid-run and every later request gets ECONNREFUSED.

```
java.lang.NoClassDefFoundError: com/fasterxml/jackson/databind/ObjectMapper
    at com.github.wnameless.json.base.JacksonJsonCore.<init>(JacksonJsonCore.java:36)
    at com.github.wnameless.json.unflattener.JsonUnflattener.unflatten(JsonUnflattener.java:71)
    at org.opensearch.observability.metrics.Metrics$Companion.collectToFlattenedJSON(Metrics.kt:84)
```

### Root cause

Metrics.collectToFlattenedJSON() flattens its output through json-flattener (JsonUnflattener), which is built against Jackson 2.x and loads com.fasterxml.jackson classes at runtime. Since #1993 (Support Jackson 3.x release line) the plugin bundled tools.jackson.core:jackson-databind (Jackson 3.x, package tools.jackson.databind), and OpenSearch core no longer exports the com.fasterxml Jackson 2.x jars on the plugin classpath after its own move to tools.jackson 3.x. So the com.fasterxml classes that json-flattener needs are no longer available at runtime. This first shipped in 3.7.0.0 and is present through 3.8.0 and main.

### Fix

Bundle the full com.fasterxml Jackson 2.x stack (jackson-core, jackson-databind, jackson-annotations) with the plugin, at the versions used by the sql and alerting plugins and the OpenSearch core Jackson 2.x line (currently 2.22.2). Shipping databind alone is not enough, because core no longer provides the com.fasterxml jackson-core on the plugin classpath, so the endpoint still failed on com.fasterxml.jackson.core.JsonProcessingException until jackson-core was bundled too.

### Testing

Added ObservabilityStatsIT, an integ test that calls GET /_plugins/_observability/_local/stats against the installed plugin distribution and asserts a 200 with the flattened metrics, so a Jackson classpath mismatch fails in integTest instead of reaching a release. A plain unit test cannot catch this because the Gradle test JVM transitively carries the com.fasterxml Jackson jars, while the assembled plugin does not.

Verified locally that the built plugin distribution bundles jackson-core 2.22.2, jackson-databind 2.22.2, and jackson-annotations 2.22, and that JsonUnflattener.unflatten runs successfully against only those bundled jars (isolated from any server-provided Jackson), producing the nested request_total and exception structure that the test asserts. The full integTest runs in CI.
